### PR TITLE
Cleanup remaining crypto APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,8 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 [[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
-source = "git+https://github.com/betrusted-io/curve25519-dalek.git?branch=main#b8f71e85d1e251aeeea4fe0da8ff8c8815e51c69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -1187,8 +1188,6 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1203,8 +1202,6 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-derive"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,6 +1574,7 @@ dependencies = [
  "ed25519 2.2.3",
  "rand_core 0.6.4",
  "sha2 0.10.8",
+ "signature 2.2.0",
  "subtle",
 ]
 
@@ -3503,7 +3504,7 @@ dependencies = [
  "bitflags 1.3.2",
  "blowfish 0.9.1",
  "cipher 0.4.4",
- "digest 0.9.0",
+ "digest 0.10.7",
  "gam",
  "hex 0.4.3",
  "hkdf",
@@ -3516,7 +3517,7 @@ dependencies = [
  "perflib",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "rkyv",
  "root-keys",
  "sha2 0.10.8",
@@ -4670,6 +4671,9 @@ name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -4801,7 +4805,7 @@ dependencies = [
  "com_rs 0.1.0 (git+https://github.com/betrusted-io/com_rs?rev=891bdd3ca8e41f81510d112483e178aea3e3a921)",
  "content-plugin-api",
  "crossbeam",
- "digest 0.9.0",
+ "digest 0.10.7",
  "dns",
  "early_settings",
  "gam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6307,7 +6307,6 @@ name = "xous-kernel"
 version = "0.9.38"
 dependencies = [
  "armv7",
- "atsama5d27",
  "bitflags 1.3.2",
  "cramium-hal",
  "critical-section",
@@ -6328,7 +6327,6 @@ dependencies = [
 name = "xous-log"
 version = "0.1.28"
 dependencies = [
- "atsama5d27",
  "cramium-hal",
  "log",
  "num-derive 0.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,16 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aead"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae06cea71059b6b79d879afcdd237a33ac61afc052fdd605815e6f3916254abf"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
  "generic-array",
@@ -26,21 +20,20 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+version = "0.8.1"
 dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures",
- "opaque-debug",
+ "cipher 0.4.4",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.1"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
+ "cfg-if",
  "cipher 0.4.4",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -80,11 +73,26 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -98,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "app-loader"
@@ -111,7 +119,7 @@ dependencies = [
  "locales",
  "log",
  "modals",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "ureq",
@@ -125,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "argh"
-version = "0.1.8"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e7e4aa7e40747e023c0761dafcb42333a9517575bbf1241747f68dd3177a62"
+checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
 dependencies = [
  "argh_derive",
  "argh_shared",
@@ -135,37 +143,39 @@ dependencies = [
 
 [[package]]
 name = "argh_derive"
-version = "0.1.8"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f2bd7ff6ed6414f4e5521bd509bae46454bbd513801767ced3f21a751ab4bc"
+checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
 dependencies = [
  "argh_shared",
- "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "argh_shared"
-version = "0.1.8"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47253b98986dafc7a3e1cf3259194f1f47ac61abb57a57f46ec09e48d004ecda"
+checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "armv7"
 version = "0.2.1"
-source = "git+https://github.com/Foundation-Devices/armv7.git?branch=update#119503459774b53a8ea4896a0b7878e0fc046a56"
+source = "git+https://github.com/Foundation-Devices/armv7.git?branch=update#e37a72f420a5e6633d9f7802c7fd094ccf8ca1f9"
 dependencies = [
- "critical-section 1.1.1",
+ "critical-section",
  "tock-registers",
 ]
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -195,7 +205,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time",
 ]
 
 [[package]]
@@ -206,7 +216,7 @@ checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
  "synstructure",
 ]
 
@@ -218,27 +228,30 @@ checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.8"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14bf7b4f565e5e717d7a7a65b2a05c0b8c96e4db636d6f780f03b15108cdd1b"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
- "critical-section 0.2.7",
+ "critical-section",
 ]
 
 [[package]]
 name = "atsama5d27"
 version = "0.1.0"
-source = "git+https://github.com/Foundation-Devices/atsama5d27.git?branch=master#b7b57849c71c720584df6aa8b778e6f46e9532ba"
+source = "git+https://github.com/Foundation-Devices/atsama5d27.git?branch=master#9e83a502e68384754bb328a5717c56f34c8618f7"
 dependencies = [
  "armv7",
+ "bitflags 2.4.2",
  "embedded-graphics",
+ "embedded-hal",
+ "png-decoder",
  "r0",
- "utralib",
+ "utralib 0.1.18",
 ]
 
 [[package]]
@@ -282,7 +295,7 @@ dependencies = [
  "locales",
  "log",
  "modals",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "trng",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -300,12 +313,6 @@ checksum = "a3caf393d93b2d453e80638d0674597020cef3382ada454faacd43d1a55a735a"
 dependencies = [
  "rustc_version 0.2.3",
 ]
-
-[[package]]
-name = "bare-metal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "base16ct"
@@ -330,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -342,15 +349,15 @@ checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bincode"
@@ -363,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb50c5a2ef4b9b1e7ae73e3a73b52ea24b20312d629f9c4df28260b7ad2c3c4"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
 dependencies = [
  "bincode_derive",
  "serde",
@@ -373,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "bincode_derive"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a45a23389446d2dd25dc8e73a7a3b3c43522b630cac068927f0649d43d719d2"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
 dependencies = [
  "virtue",
 ]
@@ -402,12 +409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
 
 [[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,9 +422,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bitmask"
@@ -433,9 +434,9 @@ checksum = "5da9b3d9f6f585199287a473f4f8dfab6566cf827d15c00c219f53c645687ead"
 
 [[package]]
 name = "bitvec"
-version = "0.22.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
@@ -454,18 +455,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -492,18 +493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,27 +500,27 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "bzip2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -550,12 +539,9 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version 0.4.0",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
@@ -572,11 +558,12 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -602,7 +589,7 @@ dependencies = [
  "locales",
  "log",
  "modals",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pddb",
  "rkyv",
@@ -632,7 +619,7 @@ dependencies = [
  "log",
  "modals",
  "net",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pddb",
  "percent-encoding",
@@ -657,15 +644,16 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
- "libc",
- "num-integer",
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
- "time 0.1.44",
- "winapi",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -704,32 +692,32 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.12"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -742,25 +730,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "codec"
 version = "0.1.0"
 dependencies = [
  "llio",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "trng",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -786,12 +765,12 @@ dependencies = [
  "com_rs 0.1.0 (git+https://github.com/betrusted-io/com_rs?rev=891bdd3ca8e41f81510d112483e178aea3e3a921)",
  "llio",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "trng",
  "typenum",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -813,9 +792,9 @@ source = "git+https://github.com/betrusted-io/com_rs?rev=891bdd3ca8e41f81510d112
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.73"
+version = "0.1.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b72fde1d7792ca3bd654f7c3ea4508f9e4d0c826e24179eabb7fcc97a90bc3"
+checksum = "8da8e35920ddd38b7bbd68866060057a69c3368301d56f8b852bd581516d4dcd"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -860,16 +839,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "cortex-m"
-version = "0.7.4"
+name = "core-foundation-sys"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ff967e867ca14eba0c34ac25cd71ea98c678e741e3915d923999bb2fe7c826"
-dependencies = [
- "bare-metal 0.2.4",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cos_table"
@@ -877,9 +850,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -890,7 +863,7 @@ version = "0.1.0"
 dependencies = [
  "graphics-server",
  "log",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -905,12 +878,12 @@ version = "0.1.0"
 dependencies = [
  "cramium-hal",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pio",
  "pio-proc",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -925,9 +898,9 @@ name = "cram-mbox1"
 version = "0.1.0"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -939,9 +912,9 @@ name = "cram-mbox2"
 version = "0.1.0"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -954,10 +927,10 @@ version = "0.1.0"
 dependencies = [
  "bitflags 1.3.2",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-names",
 ]
@@ -982,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
@@ -1008,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
  "itertools",
@@ -1018,29 +991,16 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "0.2.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
-dependencies = [
- "bare-metal 1.0.0",
- "cfg-if",
- "cortex-m",
- "riscv",
-]
-
-[[package]]
-name = "critical-section"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -1050,58 +1010,46 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
-dependencies = [
- "cfg-if",
- "lazy_static",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -1116,16 +1064,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.3"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a4e0fb04deabeb711eb20bd1179f1524c06f7e6975ebccc495f678a635887b"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1154,22 +1102,21 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
 dependencies = [
- "bstr",
  "csv-core",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
 ]
@@ -1188,7 +1135,7 @@ dependencies = [
  "p256",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "regex",
  "rfc6979 0.2.0",
  "serde",
@@ -1196,7 +1143,7 @@ dependencies = [
  "sha2 0.10.8",
  "subtle",
  "trng",
- "untrusted",
+ "untrusted 0.7.1",
  "xous-api-names",
 ]
 
@@ -1212,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d14f329cfbaf5d0e06b5e87fff7e265d2673c5ea7d2c27691a2c107db1442a0"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.4",
 ]
@@ -1232,12 +1179,36 @@ source = "git+https://github.com/betrusted-io/curve25519-dalek.git?branch=main#b
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "engine-25519",
- "engine25519-as",
- "log",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.5",
+ "platforms",
+ "rustc_version 0.4.0",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1250,7 +1221,7 @@ dependencies = [
  "digest 0.9.0",
  "engine-25519",
  "engine25519-as",
- "fiat-crypto",
+ "fiat-crypto 0.1.20",
  "hex 0.4.3",
  "log",
  "packed_simd_2",
@@ -1259,7 +1230,7 @@ dependencies = [
  "serde",
  "sha2-loader",
  "subtle",
- "utralib",
+ "utralib 0.1.24",
  "zeroize",
 ]
 
@@ -1275,12 +1246,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "fc5d6b04b3fd0ba9926f945895de7d806260a2d7431ba82e7edaecb043c4c6b8"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.5",
+ "darling_macro 0.20.5",
 ]
 
 [[package]]
@@ -1294,20 +1265,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "04e48a959bcd5c761246f5d090ebc2fbf7b9cd527a492b07a67510c108f1e7e3"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1318,34 +1289,25 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.5",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
-
-[[package]]
-name = "deflate"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
-dependencies = [
- "adler32",
-]
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "defmt"
@@ -1367,7 +1329,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1391,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "der_derive",
 ]
@@ -1414,14 +1376,22 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114792ba6b7545d3f3dd693794aed3a312a67795cd577fcc725c148d84fabe32"
+checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1445,7 +1415,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -1479,14 +1449,14 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "dlib"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading",
 ]
@@ -1502,14 +1472,14 @@ dependencies = [
  "log",
  "modals",
  "net",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pddb",
  "rkyv",
  "sntpc",
  "trng",
  "userprefs",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -1529,12 +1499,12 @@ name = "early_settings"
 version = "0.1.0"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "once_cell",
  "rkyv",
  "spinor",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -1552,17 +1522,26 @@ dependencies = [
  "der 0.5.1",
  "elliptic-curve",
  "rfc6979 0.1.0",
- "signature",
+ "signature 1.4.0",
 ]
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "serde",
- "signature",
+ "signature 1.4.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1577,12 +1556,25 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 3.2.1",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
  "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
+dependencies = [
+ "curve25519-dalek 4.1.1",
+ "ed25519 2.2.3",
+ "rand_core 0.6.4",
+ "sha2 0.10.8",
+ "subtle",
 ]
 
 [[package]]
@@ -1592,7 +1584,7 @@ dependencies = [
  "bincode 1.3.3",
  "criterion",
  "curve25519-dalek-loader",
- "ed25519",
+ "ed25519 1.5.3",
  "hex 0.4.3",
  "merlin",
  "rand 0.7.3",
@@ -1607,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
@@ -1623,7 +1615,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1631,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-graphics"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750082c65094fbcc4baf9ba31583ce9a8bb7f52cadfb96f6164b1bc7f922f32b"
+checksum = "0649998afacf6d575d126d83e68b78c0ab0e00ca2ac7e9b3db11b4cbe8274ef0"
 dependencies = [
  "az",
  "byteorder",
@@ -1644,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-graphics-core"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b1239db5f3eeb7e33e35bd10bd014e7b2537b17e071f726a09351431337cfa"
+checksum = "ba9ecd261f991856250d2207f6d8376946cd9f412a2165d3b75bc87a0bc7a044"
 dependencies = [
  "az",
  "byteorder",
@@ -1687,10 +1679,10 @@ dependencies = [
  "engine25519-as",
  "llio",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -1721,26 +1713,26 @@ checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "enum_dispatch"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
+checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
 dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "enumset"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e875f1719c16de097dee81ed675e2d9bb63096823ed3f0ca827b7dea3028bbbb"
+checksum = "226c0da7462c13fb57e5cc9e0dc8f0635e7d27f276a3a7fd30054647f669007d"
 dependencies = [
  "enumset_derive",
 ]
@@ -1751,10 +1743,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.5",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1772,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime 2.1.0",
@@ -1784,31 +1776,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.1"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
-]
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "errno"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "cc",
  "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "eyre"
-version = "0.6.8"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1816,11 +1803,17 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
 dependencies = [
- "instant",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1829,7 +1822,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1847,9 +1840,9 @@ dependencies = [
  "ffi-sys",
  "keyboard",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -1859,20 +1852,26 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.13"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35354cf6bf9d259374646f419a25c7dd0bb208d291e44dc73db557542fe017fc"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
 name = "filetime"
-version = "0.2.17"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.13",
- "windows-sys 0.36.1",
+ "redox_syscall",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1883,19 +1882,19 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.5.1",
+ "miniz_oxide 0.7.2",
 ]
 
 [[package]]
 name = "float-cmp"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
@@ -1908,18 +1907,18 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "frunk"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd67cf7d54b7e72d0ea76f3985c3747d74aee43e0218ad993b7903ba7a5395e"
+checksum = "11a351b59e12f97b4176ee78497dff72e4276fb1ceb13e19056aca7fa0206287"
 dependencies = [
  "frunk_core",
  "frunk_derives",
@@ -1933,25 +1932,25 @@ checksum = "af2469fab0bd07e64ccf0ad57a1438f63160c69b2e57f04a439653d68eb558d6"
 
 [[package]]
 name = "frunk_derives"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbc4f084ec5a3f031d24ccedeb87ab2c3189a2f33b8d070889073837d5ea09e"
+checksum = "b0fa992f1656e1707946bbba340ad244f0814009ef8c0118eb7b658395f19a2e"
 dependencies = [
  "frunk_proc_macro_helpers",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "frunk_proc_macro_helpers"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f11257f106c6753f5ffcb8e601fb39c390a088017aaa55b70c526bff15f63e"
+checksum = "35b54add839292b743aeda6ebedbd8b11e93404f902c56223e51b9ec18a13d2c"
 dependencies = [
  "frunk_core",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1965,15 +1964,15 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1986,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1996,15 +1995,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2013,38 +2012,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2074,14 +2073,14 @@ dependencies = [
  "locales",
  "log",
  "miniz_oxide 0.4.4",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "qrcode",
  "rkyv",
  "sha2 0.10.8",
  "trng",
  "tts-frontend",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2098,9 +2097,9 @@ checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "gdbstub"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec68d54b28ba0a89b2d8c62ca1aacebda9e200c5da536b417c40040f2b32299"
+checksum = "f4e02bf1b1a624d96925c608f1b268d82a76cbc587ce9e59f7c755e9ea11c75c"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -2122,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -2173,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "graphics-server"
@@ -2187,10 +2186,10 @@ dependencies = [
  "locales",
  "log",
  "minifb",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2206,7 +2205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2241,15 +2240,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "heapless"
-version = "0.7.16"
+name = "hashbrown"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version 0.4.0",
- "spin 0.9.3",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -2265,18 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hello"
@@ -2286,7 +2282,7 @@ dependencies = [
  "graphics-server",
  "locales",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "tts-frontend",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2306,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hex"
@@ -2330,13 +2326,14 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hidapi"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b1717343691998deb81766bfcd1dce6df0d5d6c37070b5a3de2bb6d39f7822"
+checksum = "798154e4b6570af74899d71155fb0072d5b17e6aa12f39c8ef22c60fb8ec99e7"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
+ "winapi",
 ]
 
 [[package]]
@@ -2347,7 +2344,7 @@ dependencies = [
  "graphics-server",
  "locales",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "tts-frontend",
  "usb-device-xous",
@@ -2386,21 +2383,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.2.8"
+name = "home"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "humantime"
@@ -2418,6 +2424,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,9 +2454,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2443,11 +2472,11 @@ dependencies = [
  "keyboard",
  "locales",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "tts-frontend",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2461,7 +2490,7 @@ version = "0.1.0"
 dependencies = [
  "graphics-server",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2475,10 +2504,10 @@ version = "0.1.0"
 dependencies = [
  "ime-plugin-api",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2493,11 +2522,11 @@ dependencies = [
  "ime-plugin-api",
  "locales",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "tts-frontend",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2513,12 +2542,22 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2545,20 +2584,20 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.4",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -2571,30 +2610,24 @@ checksum = "c9c84afb983c1eec3f46806b3c0fe5f69991729f3bde34946faa5e7c58ad7300"
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2604,10 +2637,10 @@ name = "jtag"
 version = "0.1.0"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2618,16 +2651,19 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kernel-test"
 version = "0.1.0"
 dependencies = [
  "log",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-ticktimer",
@@ -2640,11 +2676,11 @@ dependencies = [
  "early_settings",
  "llio",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "spinor",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2668,7 +2704,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -2692,21 +2728,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 dependencies = [
  "rustc-std-workspace-core",
 ]
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2716,6 +2752,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "libstd-test"
 version = "0.1.0"
 dependencies = [
@@ -2723,9 +2781,9 @@ dependencies = [
  "dns",
  "log",
  "net",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2734,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "llio"
@@ -2746,10 +2804,10 @@ dependencies = [
  "chrono",
  "locales",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2771,7 +2829,7 @@ dependencies = [
  "ed25519-dalek-loader",
  "lazy_static",
  "sha2-loader",
- "utralib",
+ "utralib 0.1.24",
  "xous-pio",
  "xous-pl230",
 ]
@@ -2790,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2800,12 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-test-client"
@@ -2822,9 +2877,9 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -2849,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "micromath"
-version = "1.1.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4010833aea396656c2f91ee704d51a6f1329ec2ab56ffd00bfd56f7481ea94"
+checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
 name = "minifb"
@@ -2867,7 +2922,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "orbclient",
- "raw-window-handle 0.4.3",
+ "raw-window-handle",
  "serde",
  "serde_derive",
  "tempfile",
@@ -2897,27 +2952,28 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "modals"
 version = "0.1.0"
 dependencies = [
- "bit_field 0.9.0",
+ "bit_field",
  "gam",
  "locales",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "trng",
  "tts-frontend",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -2943,7 +2999,7 @@ dependencies = [
  "log",
  "modals",
  "net",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pddb",
  "percent-encoding",
@@ -2976,7 +3032,7 @@ dependencies = [
  "locales",
  "log",
  "net",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pddb",
  "percent-encoding",
@@ -2996,14 +3052,14 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
 dependencies = [
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
 name = "nb"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "net"
@@ -3016,13 +3072,13 @@ dependencies = [
  "locales",
  "log",
  "modals",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pddb",
  "rkyv",
  "smoltcp",
  "trng",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -3040,12 +3096,11 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
-version = "0.22.3"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
- "cc",
  "cfg-if",
  "libc",
  "memoffset",
@@ -3053,18 +3108,28 @@ dependencies = [
 
 [[package]]
 name = "no-std-net"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bcece43b12349917e096cddfa66107277f123e6c96a5aea78711dc601a47152"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -3082,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3101,6 +3166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,7 +3179,18 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3145,30 +3227,30 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.5.7"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive 0.5.7",
+ "num_enum_derive 0.5.11",
 ]
 
 [[package]]
@@ -3182,13 +3264,13 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.7"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3199,7 +3281,7 @@ checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3213,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -3237,24 +3319,27 @@ checksum = "e0f2c5d345596a14d7c8b032a68f437955f0059f2eb9a5972371c84f7eef3227"
 
 [[package]]
 name = "orbclient"
-version = "0.3.32"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3aa1482d3a9cb7547932f54a20910090073e81b3b7b236277c91698a10f83e"
+checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
 dependencies = [
  "libc",
- "raw-window-handle 0.3.4",
- "redox_syscall 0.2.13",
+ "libredox 0.0.2",
  "sdl2",
  "sdl2-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -3270,9 +3355,9 @@ dependencies = [
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
  "libm",
@@ -3280,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "packed_struct"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c48e482b9a59ad6c2cdb06f7725e7bd33fe3525baaf4699fde7bfea6a5b77b1"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
 dependencies = [
  "bitvec",
  "packed_struct_codegen",
@@ -3290,13 +3375,13 @@ dependencies = [
 
 [[package]]
 name = "packed_struct_codegen"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e3692b867ec1d48ccb441e951637a2cc3130d0912c0059e48319e1c83e44bc"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3333,7 +3418,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3344,7 +3429,7 @@ checksum = "c0a0ea25381cd681bf1d46e04a01590ea41bffc283b1cd96b1c25cd91635546f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3359,15 +3444,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3377,24 +3462,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "passwords"
-version = "3.1.9"
+version = "3.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5dee744d341c868910c3f97727c610c9ef781fde5a5621f238163dccb7dee5c"
+checksum = "11407193a7c2bd14ec6b0ec3394da6fdcf7a4d5dcbc8c3cc38dfb17802c8d59c"
 dependencies = [
  "random-pick",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbkdf2"
@@ -3426,7 +3511,7 @@ dependencies = [
  "locales",
  "log",
  "modals",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "perflib",
  "rand 0.8.5",
@@ -3439,7 +3524,7 @@ dependencies = [
  "subtle",
  "trng",
  "tts-frontend",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -3456,7 +3541,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "once_cell",
  "regex",
 ]
@@ -3472,16 +3557,16 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "perflib"
 version = "0.1.0"
 dependencies = [
  "log",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3496,12 +3581,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.2.2",
 ]
 
 [[package]]
@@ -3515,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -3532,7 +3617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e09694b50f89f302ed531c1f2a7569f0be5867aee4ab4f8f729bbeec0078e3"
 dependencies = [
  "arrayvec",
- "num_enum 0.5.7",
+ "num_enum 0.5.11",
  "paste",
 ]
 
@@ -3545,7 +3630,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "pio",
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3561,8 +3646,8 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "regex-syntax",
- "syn 1.0.103",
+ "regex-syntax 0.6.29",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3578,15 +3663,21 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+
+[[package]]
+name = "platforms"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "plotters"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -3597,36 +3688,48 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
 name = "png"
-version = "0.17.5"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba"
+checksum = "1f6c3c3e617595665b8ea2ff95a86066be38fb121ff920a9c0eb282abcd1da5a"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
- "deflate",
- "miniz_oxide 0.5.1",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide 0.7.2",
+]
+
+[[package]]
+name = "png-decoder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e3e93d4884a2609f2dccbafabd3e25c49e89bb872ab84bfea60feaf17615944"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.4.4",
+ "num_enum 0.5.11",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3635,10 +3738,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.16"
+name = "powerfmt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "precomputed-hash"
@@ -3653,7 +3762,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3665,7 +3774,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -3682,24 +3791,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "protobuf"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee4a7d8b91800c8f167a6268d1a1026607368e1adc84e98fe044aeb905302f7"
+checksum = "b65f4a8ec18723a734e5dc09c173e0abf9690432da5340285d536edcb4dac190"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -3708,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b893e5e7d3395545d5244f8c0d33674025bd566b26c03bfda49b82c6dec45e"
+checksum = "6e85514a216b1c73111d9032e26cc7a5ecb1bb3d4d9539e91fb72a4395060f78"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3723,12 +3832,12 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1447dd751c434cc1b415579837ebd0411ed7d67d465f38010da5d7cd33af4d"
+checksum = "77d6fbd6697c9e531873e81cec565a85e226b99a0f10e1acc079be057fe2fcba"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "protobuf",
  "protobuf-support",
@@ -3739,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca157fe12fc7ee2e315f2f735e27df41b3d97cdd70ea112824dac1ffb08ee1c"
+checksum = "6872f4d4f4b98303239a2b5838f5bbbb77b01ffc892d627957f37a22d7cfe69c"
 dependencies = [
  "thiserror",
 ]
@@ -3763,7 +3872,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3783,18 +3892,18 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -3807,9 +3916,9 @@ checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3832,7 +3941,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3852,7 +3961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3866,9 +3975,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.11",
 ]
@@ -3888,14 +3997,14 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "random-number"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9c434a752bd6bde0199f771763c89e4870c2cb159ddafacd19948588477379"
+checksum = "3a3da5cbb4c27c5150c03a54a7e4745437cd90f9e329ae657c0b889a144bb7be"
 dependencies = [
  "proc-macro-hack",
  "rand 0.8.5",
@@ -3904,32 +4013,22 @@ dependencies = [
 
 [[package]]
 name = "random-number-macro-impl"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f50024fe705be34d953ca47f4617ce3a665caa1011f14a48e6a8a6ec911f0f"
+checksum = "8b86292cf41ccfc96c5de7165c1c53d5b4ac540c5bab9d1857acbe9eba5f1a0b"
 dependencies = [
  "proc-macro-hack",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "random-pick"
-version = "1.2.15"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6239a2a71f5519a5f9f1c97ec04d7dc10292683408e720189ca839f271ba25d2"
+checksum = "c179499072da789afe44127d5f4aa6012de2c2f96ef759990196b37387a2a0f8"
 dependencies = [
  "random-number",
-]
-
-[[package]]
-name = "raw-window-handle"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28f55143d0548dad60bb4fbdc835a3d7ac6acc3324506450c5fdd6e42903a76"
-dependencies = [
- "libc",
- "raw-window-handle 0.4.3",
 ]
 
 [[package]]
@@ -3943,88 +4042,78 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom 0.2.11",
- "redox_syscall 0.2.13",
+ "libredox 0.0.1",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-automata",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
+name = "regex-syntax"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "repl"
@@ -4041,7 +4130,7 @@ dependencies = [
  "llio",
  "locales",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "trng",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4068,7 +4157,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c0788437d5ee113c49af91d3594ebc4fcdcc962f8b6df5aa1c3eeafd8ad95de"
 dependencies = [
- "crypto-bigint 0.4.3",
+ "crypto-bigint 0.4.9",
  "hmac 0.12.1",
  "zeroize",
 ]
@@ -4084,7 +4173,7 @@ dependencies = [
  "once_cell",
  "rkyv",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "winapi",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-names",
@@ -4092,24 +4181,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "riscv"
-version = "0.7.0"
+name = "ring"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
- "bare-metal 1.0.0",
- "bit_field 0.10.1",
- "riscv-target",
-]
-
-[[package]]
-name = "riscv-target"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
-dependencies = [
- "lazy_static",
- "regex",
+ "cc",
+ "getrandom 0.2.11",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4132,7 +4214,7 @@ checksum = "95a169f6bc5a81033e86ed39d0f4150e2608160b73d2b93c6e8e6a3efa873f14"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4146,9 +4228,9 @@ dependencies = [
  "byteorder",
  "cipher 0.4.4",
  "com",
- "curve25519-dalek",
- "digest 0.9.0",
- "ed25519-dalek",
+ "curve25519-dalek 4.1.1",
+ "digest 0.10.7",
+ "ed25519-dalek 2.1.0",
  "engine-25519",
  "gam",
  "graphics-server",
@@ -4159,9 +4241,9 @@ dependencies = [
  "locales",
  "log",
  "modals",
- "num-derive",
+ "num-derive 0.4.1",
  "num-traits",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "rkyv",
  "sha2 0.10.8",
  "spinor",
@@ -4169,7 +4251,7 @@ dependencies = [
  "trng",
  "tts-frontend",
  "usb-device-xous",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -4207,7 +4289,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.9",
+ "semver 1.0.21",
 ]
 
 [[package]]
@@ -4221,47 +4303,37 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki 0.101.5",
+ "ring 0.17.7",
+ "rustls-webpki",
  "sct",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
-dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4272,9 +4344,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -4287,24 +4359,24 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4316,7 +4388,6 @@ dependencies = [
  "bitflags 1.3.2",
  "lazy_static",
  "libc",
- "raw-window-handle 0.4.3",
  "sdl2-sys",
 ]
 
@@ -4327,7 +4398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3586be2cf6c0a8099a79a12b4084357aa9b3e0b0d7980e3b67aaf7a9d55f9f0"
 dependencies = [
  "cfg-if",
- "cmake",
  "libc",
  "version-compare",
 ]
@@ -4362,9 +4432,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.9"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "semver-parser"
@@ -4374,18 +4444,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.168"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d614f89548720367ded108b3c843be93f3a341e22d5674ca0dd5cd57f34926af"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.6"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
  "serde",
 ]
@@ -4402,35 +4472,35 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.168"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fe589678c688e44177da4f27152ee2d190757271dc7f1d5b6b9f68d869d641"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
- "itoa 1.0.2",
+ "itoa",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.9"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4453,7 +4523,7 @@ dependencies = [
  "darling 0.13.4",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4489,11 +4559,11 @@ dependencies = [
  "crypto-common",
  "digest 0.10.7",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rand 0.8.5",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -4508,14 +4578,14 @@ dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
  "opaque-debug",
- "utralib",
+ "utralib 0.1.24",
 ]
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -4527,16 +4597,16 @@ dependencies = [
  "aes 0.8.1",
  "base64 0.20.0",
  "chrono",
- "cipher 0.3.0",
+ "cipher 0.4.4",
  "codec",
  "com",
  "com_rs 0.1.0 (git+https://github.com/betrusted-io/com_rs?rev=891bdd3ca8e41f81510d112483e178aea3e3a921)",
  "content-plugin-api",
  "cos_table",
- "curve25519-dalek",
- "digest 0.9.0",
+ "curve25519-dalek 4.1.1",
+ "digest 0.10.7",
  "dns",
- "ed25519-dalek",
+ "ed25519-dalek 2.1.0",
  "engine-25519",
  "gam",
  "graphics-server",
@@ -4551,7 +4621,7 @@ dependencies = [
  "log",
  "modals",
  "net",
- "num-derive",
+ "num-derive 0.4.1",
  "num-traits",
  "pddb",
  "perflib",
@@ -4560,7 +4630,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "random-pick",
- "ring",
+ "ring 0.16.20",
  "rkyv",
  "root-keys",
  "sha2 0.10.8",
@@ -4575,7 +4645,7 @@ dependencies = [
  "tungstenite",
  "url",
  "usb-device-xous",
- "utralib",
+ "utralib 0.1.24",
  "x25519-dalek",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
@@ -4592,26 +4662,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 dependencies = [
  "digest 0.9.0",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.10"
+name = "signature"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smoltcp"
@@ -4631,9 +4716,9 @@ dependencies = [
 
 [[package]]
 name = "sntpc"
-version = "0.3.1"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd9ef0de174c00dfc61054e7402b8b133a03943c2c9697c497650c4d2cf52f3"
+checksum = "629a9f38f83d7b8a14c702deecc8e431220b1570d3d927daa567b87d69346524"
 dependencies = [
  "no-std-net",
 ]
@@ -4655,9 +4740,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
@@ -4670,12 +4755,12 @@ dependencies = [
  "lazy_static",
  "llio",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rand 0.8.5",
  "rkyv",
  "trng",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -4727,7 +4812,7 @@ dependencies = [
  "log",
  "modals",
  "net",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pddb",
  "rkyv",
@@ -4736,7 +4821,7 @@ dependencies = [
  "trng",
  "usb-device-xous",
  "userprefs",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -4787,6 +4872,16 @@ dependencies = [
 
 [[package]]
 name = "svd2utra"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbb573d9b7f48e88d4927d99a4e8b86a98e423e812f7245a36319031c1c0ca4"
+dependencies = [
+ "convert_case",
+ "quick-xml",
+]
+
+[[package]]
+name = "svd2utra"
 version = "0.1.22"
 dependencies = [
  "quick-xml",
@@ -4794,9 +4889,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4805,9 +4900,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4822,7 +4917,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -4834,16 +4929,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall 0.2.13",
- "remove_dir_all",
- "winapi",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4859,9 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -4884,36 +4978,37 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -4939,22 +5034,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
-dependencies = [
- "itoa 1.0.2",
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -4962,16 +5049,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -5005,25 +5093,25 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls"
 version = "0.1.0"
 dependencies = [
- "der 0.7.7",
+ "der 0.7.8",
  "locales",
  "log",
  "modals",
  "net",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "pddb",
  "rkyv",
  "rustls",
- "rustls-webpki 0.101.5",
+ "rustls-webpki",
  "sha2 0.10.8",
  "ureq",
  "webpki-roots 0.24.0",
@@ -5043,9 +5131,9 @@ checksum = "696941a0aee7e276a165a978b37918fd5d22c55c3d6bda197813070ca9c0f21c"
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -5059,25 +5147,24 @@ dependencies = [
  "clap 2.34.0",
  "crc",
  "csv",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "env_logger 0.7.1",
  "log",
  "pem",
  "pkcs8",
- "ring",
+ "ring 0.16.20",
  "sha2 0.9.9",
- "svd2utra",
+ "svd2utra 0.1.22",
  "xmas-elf",
  "xous-semver",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5085,20 +5172,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5106,22 +5193,22 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.11"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "ansi_term",
+ "nu-ansi-term",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -5146,7 +5233,7 @@ dependencies = [
  "gam",
  "graphics-server",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "usb-device-xous",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5160,13 +5247,13 @@ name = "trng"
 version = "0.1.0"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.4.1",
  "num-traits",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -5181,10 +5268,10 @@ version = "0.1.0"
 dependencies = [
  "codec",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -5214,9 +5301,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uf2_block"
@@ -5230,15 +5317,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -5250,22 +5337,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
@@ -5284,28 +5365,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "ureq"
-version = "2.7.1"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.7",
  "flate2",
  "log",
  "once_cell",
  "rustls",
- "rustls-webpki 0.100.1",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.23.1",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -5333,9 +5420,9 @@ dependencies = [
  "llio",
  "log",
  "modals",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
- "num_enum 0.5.7",
+ "num_enum 0.5.11",
  "packed_struct",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5345,7 +5432,7 @@ dependencies = [
  "usbd-serial",
  "usbd_mass_storage 0.1.0",
  "usbd_scsi 0.1.1",
- "utralib",
+ "utralib 0.1.24",
  "vcell",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
@@ -5365,12 +5452,12 @@ dependencies = [
  "embedded-time",
  "keyboard",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "usb-device",
- "utralib",
+ "utralib 0.1.24",
  "vcell",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
@@ -5484,7 +5571,7 @@ dependencies = [
 name = "userprefs"
 version = "0.1.0"
 dependencies = [
- "bincode 2.0.0-rc.2",
+ "bincode 2.0.0-rc.3",
  "keyboard",
  "pddb",
  "prefsgenerator",
@@ -5499,9 +5586,17 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utralib"
+version = "0.1.18"
+source = "git+https://github.com/Foundation-Devices/atsama5d27.git?branch=master#9e83a502e68384754bb328a5717c56f34c8618f7"
+dependencies = [
+ "svd2utra 0.1.15",
+]
+
+[[package]]
+name = "utralib"
 version = "0.1.24"
 dependencies = [
- "svd2utra",
+ "svd2utra 0.1.22",
 ]
 
 [[package]]
@@ -5535,14 +5630,14 @@ dependencies = [
  "log",
  "modals",
  "net",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "passwords",
  "pddb",
  "perflib",
  "persistent_store",
  "rand 0.8.5",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "random-pick",
  "rkyv",
  "sha1",
@@ -5553,7 +5648,7 @@ dependencies = [
  "tts-frontend",
  "usb-device-xous",
  "userprefs",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -5573,10 +5668,10 @@ dependencies = [
  "base32",
  "base64 0.5.2",
  "cbor",
- "clap 3.2.12",
+ "clap 3.2.25",
  "csv",
  "ctaphid",
- "env_logger 0.9.0",
+ "env_logger 0.9.3",
  "hex 0.4.3",
  "hidapi",
  "log",
@@ -5602,9 +5697,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88247b92c1df6b6de80ddc290f3976dbdf2f5f5d3fd049a9fb598c6dd5ca73"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"
@@ -5614,9 +5709,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "virtue"
-version = "0.0.8"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b60dcd6a64dd45abf9bd426970c9843726da7fc08f44cd6fcebf68c21220a63"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "void"
@@ -5625,22 +5720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
-name = "volatile-register"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
-dependencies = [
- "vcell",
-]
-
-[[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -5649,12 +5734,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -5669,9 +5748,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5679,24 +5758,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5706,9 +5785,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5716,28 +5795,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.30"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4464b3f74729a25f42b1a0cd9e6a515d2f25001f3535a6cfaf35d34a4de3bab"
+checksum = "139bd73305d50e1c1c4333210c0db43d989395b64a237bd35c10ef3832a7f70c"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -5749,19 +5828,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.30"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c5a6f82cc6093a321ca5fb3dc9327fe51675d477b3799b4a9375bac3b7b4c"
+checksum = "70072aebfe5da66d2716002c729a14e4aec4da0e23cc2ea66323dac541c93928"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91223460e73257f697d9e23d401279123d36039a3f7a449e983f123292d4458f"
+checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
 dependencies = [
  "bitflags 1.3.2",
  "downcast-rs",
@@ -5775,9 +5855,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-commons"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6e5e340d7c13490eca867898c4cec5af56c27a5ffe5c80c6fc4708e22d33e"
+checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
 dependencies = [
  "nix",
  "once_cell",
@@ -5787,9 +5867,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52758f13d5e7861fc83d942d3d99bf270c83269575e52ac29e5b73cb956a6bd"
+checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
 dependencies = [
  "nix",
  "wayland-client",
@@ -5798,9 +5878,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60147ae23303402e41fe034f74fb2c35ad0780ee88a1c40ac09a3be1e7465741"
+checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
 dependencies = [
  "bitflags 1.3.2",
  "wayland-client",
@@ -5810,9 +5890,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a1ed3143f7a143187156a2ab52742e89dac33245ba505c17224df48939f9e0"
+checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5821,9 +5901,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.29.4"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9341df79a8975679188e37dab3889bfa57c44ac2cb6da166f519a81cbe452d4"
+checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
 dependencies = [
  "dlib",
  "lazy_static",
@@ -5832,21 +5912,12 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki 0.100.1",
 ]
 
 [[package]]
@@ -5855,18 +5926,25 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
 dependencies = [
- "rustls-webpki 0.101.5",
+ "rustls-webpki",
 ]
 
 [[package]]
-name = "which"
-version = "4.3.0"
+name = "webpki-roots"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -5887,9 +5965,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -5901,16 +5979,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.36.1"
+name = "windows-core"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -5919,95 +5993,131 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "wycheproof-import"
@@ -6021,40 +6131,39 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
 
 [[package]]
 name = "x11-dl"
-version = "2.19.1"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea26926b4ce81a6f5d9d0f3a0bc401e5a37c6ae14a1bfaa8ff6099ca80038c59"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
 dependencies = [
- "lazy_static",
  "libc",
+ "once_cell",
  "pkg-config",
 ]
 
 [[package]]
 name = "x25519-dalek"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
- "curve25519-dalek",
- "rand_core 0.5.1",
- "zeroize",
+ "curve25519-dalek 4.1.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "x509-parser"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab0c2f54ae1d92f4fcb99c0b7ccf0b1e3451cbd395e5f115ccbdbcb18d4f634"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -6064,32 +6173,29 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.20",
+ "time",
 ]
 
 [[package]]
 name = "xcursor"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7"
-dependencies = [
- "nom",
-]
+checksum = "6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911"
 
 [[package]]
 name = "xmas-elf"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f820cc767d65b32eef9d7ce7201448f28501c59edc55d47b71375fea579fc2df"
+checksum = "42c49817e78342f7f30a181573d82ff55b88a35f86ccaf07fc64b3008f56d1c6"
 dependencies = [
  "zero",
 ]
 
 [[package]]
 name = "xml-rs"
-version = "0.8.4"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "xous"
@@ -6116,7 +6222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85d3565a3ff5a8228835a273a1d3e02f5fe88c3086711d96eec6ea2067ae2980"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-ipc 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6129,7 +6235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "371e870d9fca17643bae54cb4b8389bc53358b28973d835325575e0b9efaf8f8"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6144,10 +6250,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb84e28d54ff3bd7002ec9d0df3044839eee9bed659aa5589261462b5413ce7"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -6161,7 +6267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c91dbb8419dd180fae08200c46cb2a8d9a14e1c1447f224ed901fff006823269"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6200,7 +6306,7 @@ dependencies = [
  "atsama5d27",
  "bitflags 1.3.2",
  "cramium-hal",
- "critical-section 1.1.1",
+ "critical-section",
  "crossbeam-channel",
  "gdbstub",
  "gdbstub_arch",
@@ -6209,7 +6315,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "stats_alloc",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-riscv",
 ]
@@ -6218,13 +6324,12 @@ dependencies = [
 name = "xous-log"
 version = "0.1.28"
 dependencies = [
- "atsama5d27",
  "cramium-hal",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-ipc 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6235,10 +6340,10 @@ name = "xous-names"
 version = "0.9.37"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -6253,7 +6358,7 @@ dependencies = [
  "log",
  "pio",
  "pio-proc",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6266,7 +6371,7 @@ dependencies = [
  "log",
  "pio",
  "pio-proc",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-pio",
 ]
@@ -6277,8 +6382,8 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63ec51bd5669f944bc375cc2c8ba93e28d7e697d13605a3454c331ea5f0b461a"
 dependencies = [
- "bare-metal 0.2.4",
- "bit_field 0.9.0",
+ "bare-metal",
+ "bit_field",
 ]
 
 [[package]]
@@ -6292,10 +6397,10 @@ name = "xous-susres"
 version = "0.1.36"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -6307,12 +6412,11 @@ dependencies = [
 name = "xous-ticktimer"
 version = "0.1.32"
 dependencies = [
- "atsama5d27",
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
- "utralib",
+ "utralib 0.1.24",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "xous-api-log",
  "xous-api-names",
@@ -6329,7 +6433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4201314c50898a02150ab2d5e46fd58283e36506ffabc3e13b22e3f1b85873ba"
 dependencies = [
  "log",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "rkyv",
  "xous 0.9.57 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6344,7 +6448,7 @@ source = "git+https://github.com/betrusted-io/xous-usb-hid.git?branch=main#793ec
 dependencies = [
  "frunk",
  "fugit",
- "heapless 0.7.16",
+ "heapless 0.7.17",
  "num_enum 0.6.1",
  "option-block",
  "packed_struct",
@@ -6362,7 +6466,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_json",
- "svd2utra",
+ "svd2utra 0.1.22",
  "tempfile",
  "ureq",
  "zip",
@@ -6370,9 +6474,9 @@ dependencies = [
 
 [[package]]
 name = "zero"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"
+checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
 
 [[package]]
 name = "zeroize"
@@ -6385,23 +6489,22 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
- "synstructure",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "zip"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes 0.7.5",
+ "aes 0.8.3",
  "byteorder",
  "bzip2",
  "constant_time_eq",
@@ -6411,7 +6514,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
  "sha1",
- "time 0.3.20",
+ "time",
  "zstd",
 ]
 
@@ -6436,11 +6539,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "cfg-if",
  "compiler_builtins",
@@ -3941,7 +3941,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -4037,7 +4037,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "libredox 0.0.1",
  "thiserror",
 ]
@@ -4149,7 +4149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,20 +20,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.1"
-dependencies = [
- "cipher 0.4.4",
-]
-
-[[package]]
-name = "aes"
 version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures",
+ "cipher",
 ]
 
 [[package]]
@@ -43,8 +32,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
 dependencies = [
  "aead",
- "aes 0.8.1",
- "cipher 0.4.4",
+ "aes",
+ "cipher",
  "ctr",
  "polyval",
  "subtle",
@@ -57,14 +46,14 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
 dependencies = [
- "aes 0.8.1",
+ "aes",
 ]
 
 [[package]]
 name = "aes-test"
 version = "0.1.0"
 dependencies = [
- "aes 0.8.1",
+ "aes",
  "hex-literal",
  "log",
  "xous 0.9.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -473,23 +462,12 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3ff3fc1de48c1ac2e3341c4df38b0d1bfb8fdf04632a187c8b75aaa319a7ab"
-dependencies = [
- "byteorder",
- "cipher 0.3.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "blowfish"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -549,7 +527,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -654,15 +632,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -814,6 +783,12 @@ name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -1125,7 +1100,7 @@ dependencies = [
 name = "ctap-crypto"
 version = "0.1.0"
 dependencies = [
- "aes 0.8.1",
+ "aes",
  "arrayref",
  "byteorder",
  "cbc",
@@ -1163,7 +1138,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1171,19 +1146,6 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
-
-[[package]]
-name = "curve25519-dalek"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "curve25519-dalek"
@@ -1197,6 +1159,7 @@ dependencies = [
  "platforms",
  "rustc_version 0.4.0",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1344,7 +1307,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid",
+ "const-oid 0.7.1",
  "pem-rfc7468",
 ]
 
@@ -1354,7 +1317,9 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
+ "const-oid 0.9.6",
  "der_derive",
+ "zeroize",
 ]
 
 [[package]]
@@ -1538,6 +1503,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8 0.10.2",
  "signature 2.2.0",
 ]
 
@@ -1549,30 +1515,18 @@ checksum = "e18997d4604542d0736fae2c5ad6de987f0a50530cbcc14a7ce5a685328a252d"
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
-dependencies = [
- "curve25519-dalek 3.2.1",
- "ed25519 1.5.3",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek",
  "ed25519 2.2.3",
  "rand_core 0.6.4",
+ "serde",
  "sha2 0.10.8",
  "signature 2.2.0",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3495,12 +3449,12 @@ dependencies = [
 name = "pddb"
 version = "0.1.0"
 dependencies = [
- "aes 0.8.1",
+ "aes",
  "aes-gcm-siv",
  "bitfield",
  "bitflags 1.3.2",
- "blowfish 0.9.1",
- "cipher 0.4.4",
+ "blowfish",
+ "cipher",
  "digest 0.10.7",
  "gam",
  "hex 0.4.3",
@@ -3655,8 +3609,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
  "der 0.5.1",
- "spki",
+ "spki 0.5.4",
  "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.8",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4219,16 +4183,16 @@ dependencies = [
 name = "root-keys"
 version = "0.1.0"
 dependencies = [
- "aes 0.8.1",
+ "aes",
  "aes-gcm-siv",
  "aes-kw",
- "blowfish 0.8.0",
+ "blowfish",
  "byteorder",
- "cipher 0.4.4",
+ "cipher",
  "com",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek",
  "digest 0.10.7",
- "ed25519-dalek 2.1.0",
+ "ed25519-dalek",
  "engine-25519",
  "gam",
  "graphics-server",
@@ -4414,7 +4378,7 @@ checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
  "der 0.5.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.8.0",
  "subtle",
  "zeroize",
 ]
@@ -4592,19 +4556,19 @@ dependencies = [
 name = "shellchat"
 version = "0.1.0"
 dependencies = [
- "aes 0.8.1",
+ "aes",
  "base64 0.20.0",
  "chrono",
- "cipher 0.4.4",
+ "cipher",
  "codec",
  "com",
  "com_rs 0.1.0 (git+https://github.com/betrusted-io/com_rs?rev=891bdd3ca8e41f81510d112483e178aea3e3a921)",
  "content-plugin-api",
  "cos_table",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek",
  "digest 0.10.7",
  "dns",
- "ed25519-dalek 2.1.0",
+ "ed25519-dalek",
  "engine-25519",
  "gam",
  "graphics-server",
@@ -4670,6 +4634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4778,6 +4743,16 @@ checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
  "base64ct",
  "der 0.5.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.8",
 ]
 
 [[package]]
@@ -5148,13 +5123,13 @@ dependencies = [
  "clap 2.34.0",
  "crc",
  "csv",
- "ed25519-dalek 1.0.1",
+ "ed25519-dalek",
  "env_logger 0.7.1",
  "log",
  "pem",
- "pkcs8",
+ "pkcs8 0.8.0",
  "ring 0.16.20",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "svd2utra 0.1.22",
  "xmas-elf",
  "xous-semver",
@@ -6156,7 +6131,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek",
  "rand_core 0.6.4",
 ]
 
@@ -6480,9 +6455,9 @@ checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]
@@ -6504,7 +6479,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
- "aes 0.8.3",
+ "aes",
  "byteorder",
  "bzip2",
  "constant_time_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,9 +144,9 @@ sha2_legacy = { git = "https://github.com/RustCrypto/hashes.git", tag = "sha2-v0
 path = "services/aes"
 
 [patch.crates-io.curve25519-dalek]
-git = "https://github.com/betrusted-io/curve25519-dalek.git"
-branch = "main"
-#path = "../curve25519-dalek"  # when doing local dev work
+#git = "https://github.com/betrusted-io/curve25519-dalek.git"
+#branch = "main"
+path = "../curve25519-dalek/curve25519-dalek"  # when doing local dev work
 # feature overrides are specified at the crate level
 
 [patch."https://github.com/betrusted-io/xous-engine-25519.git"]

--- a/apps/vault/Cargo.toml
+++ b/apps/vault/Cargo.toml
@@ -39,7 +39,7 @@ ctap-crypto = { path = "libraries/crypto" }
 cbor = { path = "libraries/cbor" }
 persistent_store = { path = "libraries/persistent_store" }
 ed25519-compact = { version = "1", default-features = false, optional = true }
-rand = { version = "0.8.4", optional = true }
+rand = { version = "0.8.5", optional = true }
 
 # ux formatting
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/apps/vault/Cargo.toml
+++ b/apps/vault/Cargo.toml
@@ -43,7 +43,7 @@ rand = { version = "0.8.4", optional = true }
 
 # ux formatting
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-chrono = { version = "0.4.19", default-features = false, features = ["std"] }
+chrono = { version = "0.4.33", default-features = false, features = ["std"] }
 
 # password generation
 passwords = "3.1.9"

--- a/apps/vault/src/prereqs.rs
+++ b/apps/vault/src/prereqs.rs
@@ -211,7 +211,7 @@ pub(crate) fn ntp_updater(time_conn: xous::CID) {
                     match result {
                         Ok(time) => {
                             log::debug!("Got NTP time: {}.{}", time.sec(), time.sec_fraction());
-                            let current_time = Utc.ymd(1970, 1, 1).and_hms(0, 0, 0)
+                            let current_time = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap()
                                 + chrono::Duration::seconds(time.sec() as i64);
                             log::debug!("Setting UTC time: {:?}", current_time.to_string());
                             xous::send_message(

--- a/apps/vault/src/storage.rs
+++ b/apps/vault/src/storage.rs
@@ -766,8 +766,8 @@ impl From<PasswordRecord> for Vec<u8> {
 /// target
 fn utc_now() -> DateTime<Utc> {
     let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("system time before Unix epoch");
-    let naive = NaiveDateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos() as u32);
-    DateTime::from_utc(naive, Utc)
+    let naive = NaiveDateTime::from_timestamp_opt(now.as_secs() as i64, now.subsec_nanos() as u32).unwrap();
+    DateTime::from_naive_utc_and_offset(naive, Utc)
 }
 
 pub fn hex(data: Vec<u8>) -> String {

--- a/apps/vault/src/vault_api.rs
+++ b/apps/vault/src/vault_api.rs
@@ -63,7 +63,10 @@ pub fn atime_to_str(req_atime: u64) -> String {
         request_str.push_str(t!("vault.u2f.appinfo.never", locales::LANG));
     } else {
         let now = utc_now();
-        let atime = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(req_atime as i64, 0), Utc);
+        let atime = DateTime::<Utc>::from_naive_utc_and_offset(
+            NaiveDateTime::from_timestamp_opt(req_atime as i64, 0).unwrap(),
+            Utc,
+        );
         // avoid format! macro, it is too slow.
         if now.signed_duration_since(atime).num_days() > 1 {
             request_str.push_str(t!("vault.u2f.appinfo.last_authtime", locales::LANG));
@@ -90,8 +93,8 @@ pub fn atime_to_str(req_atime: u64) -> String {
 /// target
 pub fn utc_now() -> DateTime<Utc> {
     let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("system time before Unix epoch");
-    let naive = NaiveDateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos() as u32);
-    DateTime::from_utc(naive, Utc)
+    let naive = NaiveDateTime::from_timestamp_opt(now.as_secs() as i64, now.subsec_nanos() as u32).unwrap();
+    DateTime::from_naive_utc_and_offset(naive, Utc)
 }
 
 /// app info format:

--- a/imports/getrandom/CHANGELOG.md
+++ b/imports/getrandom/CHANGELOG.md
@@ -4,6 +4,134 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.12] - 2024-01-09
+### Fixed
+- Custom backend for targets without atomics [#385]
+
+### Changed
+- Improve robustness of the Hermit backend and `sys_fill_exact` [#386]
+- Raise minimum supported Apple OS versions to macOS 10.12 and iOS 10 [#388]
+
+### Added
+- Document platform support policy [#387]
+
+[#385]: https://github.com/rust-random/getrandom/pull/385
+[#386]: https://github.com/rust-random/getrandom/pull/386
+[#387]: https://github.com/rust-random/getrandom/pull/387
+[#388]: https://github.com/rust-random/getrandom/pull/388
+
+## [0.2.11] - 2023-11-08
+### Added
+- GNU/Hurd support [#370]
+
+### Changed
+- Renamed `__getrandom_internal` to `__GETRANDOM_INTERNAL`  [#369]
+- Updated link to Hermit docs [#374]
+
+[#369]: https://github.com/rust-random/getrandom/pull/369
+[#370]: https://github.com/rust-random/getrandom/pull/370
+[#374]: https://github.com/rust-random/getrandom/pull/374
+
+## [0.2.10] - 2023-06-06
+### Added
+- Support for PS Vita (`armv7-sony-vita-newlibeabihf`) [#359]
+
+### Changed
+- Use getentropy from libc on Emscripten targets [#362]
+
+[#359]: https://github.com/rust-random/getrandom/pull/359
+[#362]: https://github.com/rust-random/getrandom/pull/362
+
+## [0.2.9] - 2023-04-06
+### Added
+- AIX support [#282]
+- `getrandom_uninit` function [#291]
+- `wasm64-unknown-unknown` support [#303]
+- tvOS and watchOS support [#317]
+- QNX/nto support [#325]
+- Support for `getrandom` syscall on NetBSD ≥ 10.0 [#331]
+- `RtlGenRandom` fallback for non-UWP Windows [#337]
+
+### Breaking Changes
+- Update MSRV to 1.36 [#291]
+
+### Fixed
+- Solaris/OpenBSD/Dragonfly build [#301]
+
+### Changed
+- Update MSRV to 1.36 [#291]
+- Use getentropy on Emscripten [#307]
+- Solaris: consistantly use `/dev/random` source [#310]
+- Move 3ds selection above rdrand/js/custom fallback [#312]
+- Remove buffer zeroing from Node.js implementation [#315]
+- Use `open` instead of `open64` [#326]
+- Remove #cfg from bsd_arandom.rs [#332]
+- Hermit: use `sys_read_entropy` syscall [#333]
+- Eliminate potential panic in sys_fill_exact [#334]
+- rdrand: Remove checking for 0 and !0 and instead check CPU family and do a self-test [#335]
+- Move `__getrandom_custom` definition into a const block [#344]
+- Switch the custom backend to Rust ABI [#347]
+
+[#282]: https://github.com/rust-random/getrandom/pull/282
+[#291]: https://github.com/rust-random/getrandom/pull/291
+[#301]: https://github.com/rust-random/getrandom/pull/301
+[#303]: https://github.com/rust-random/getrandom/pull/303
+[#307]: https://github.com/rust-random/getrandom/pull/307
+[#310]: https://github.com/rust-random/getrandom/pull/310
+[#312]: https://github.com/rust-random/getrandom/pull/312
+[#315]: https://github.com/rust-random/getrandom/pull/315
+[#317]: https://github.com/rust-random/getrandom/pull/317
+[#325]: https://github.com/rust-random/getrandom/pull/325
+[#326]: https://github.com/rust-random/getrandom/pull/326
+[#331]: https://github.com/rust-random/getrandom/pull/331
+[#332]: https://github.com/rust-random/getrandom/pull/332
+[#333]: https://github.com/rust-random/getrandom/pull/333
+[#334]: https://github.com/rust-random/getrandom/pull/334
+[#335]: https://github.com/rust-random/getrandom/pull/335
+[#337]: https://github.com/rust-random/getrandom/pull/337
+[#344]: https://github.com/rust-random/getrandom/pull/344
+[#347]: https://github.com/rust-random/getrandom/pull/347
+
+## [0.2.8] - 2022-10-20
+### Changed
+- The [Web Cryptography API] will now be preferred on `wasm32-unknown-unknown`
+  when using the `"js"` feature, even on Node.js [#284] [#295]
+
+### Added
+- Added benchmarks to track buffer initialization cost [#272]
+
+### Fixed
+- Use `$crate` in `register_custom_getrandom!` [#270]
+
+### Documentation
+- Add information about enabling `"js"` feature [#280]
+- Fix link to `wasm-bindgen` [#278]
+- Document the varied implementations for underlying randomness sources [#276]
+
+[Web Cryptography API]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API
+[#284]: https://github.com/rust-random/getrandom/pull/284
+[#295]: https://github.com/rust-random/getrandom/pull/295
+[#272]: https://github.com/rust-random/getrandom/pull/272
+[#270]: https://github.com/rust-random/getrandom/pull/270
+[#280]: https://github.com/rust-random/getrandom/pull/280
+[#278]: https://github.com/rust-random/getrandom/pull/278
+[#276]: https://github.com/rust-random/getrandom/pull/276
+
+## [0.2.7] - 2022-06-14
+### Changed
+- Update `wasi` dependency to `0.11` [#253]
+
+### Fixed
+- Use `AtomicPtr` instead of `AtomicUsize` for Strict Provenance compatibility. [#263]
+
+### Documentation
+- Add comments explaining use of fallback mechanisms [#257] [#260]
+
+[#263]: https://github.com/rust-random/getrandom/pull/263
+[#260]: https://github.com/rust-random/getrandom/pull/260
+[#253]: https://github.com/rust-random/getrandom/pull/253
+[#257]: https://github.com/rust-random/getrandom/pull/257
+
 ## [0.2.6] - 2022-03-28
 ### Added
 - Nintendo 3DS (`armv6k-nintendo-3ds`) support [#248]
@@ -55,7 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.2] - 2021-01-19
 ### Changed
 - Forward `rustc-dep-of-std` to dependencies. [#198]
-- Highlight feature-dependend functionality in documentation using the `doc_cfg` feature. [#200]
+- Highlight feature-dependent functionality in documentation using the `doc_cfg` feature. [#200]
 
 [#198]: https://github.com/rust-random/getrandom/pull/198
 [#200]: https://github.com/rust-random/getrandom/pull/200
@@ -185,7 +313,7 @@ disabled `dummy` feature. [#90]
 ## [0.1.9] - 2019-08-14 [YANKED]
 ### Changed
 - Remove `std` dependency for opening and reading files. [#58]
-- Use `wasi` isntead of `libc` on WASI target. [#64]
+- Use `wasi` instead of `libc` on WASI target. [#64]
 - By default emit a compile-time error when built for an unsupported target.
 This behaviour can be disabled by using the `dummy` feature. [#71]
 
@@ -291,7 +419,13 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
-[0.2.5]: https://github.com/rust-random/getrandom/compare/v0.2.5...v0.2.6
+[0.2.12]: https://github.com/rust-random/getrandom/compare/v0.2.11...v0.2.12
+[0.2.11]: https://github.com/rust-random/getrandom/compare/v0.2.10...v0.2.11
+[0.2.10]: https://github.com/rust-random/getrandom/compare/v0.2.9...v0.2.10
+[0.2.9]: https://github.com/rust-random/getrandom/compare/v0.2.8...v0.2.9
+[0.2.8]: https://github.com/rust-random/getrandom/compare/v0.2.7...v0.2.8
+[0.2.7]: https://github.com/rust-random/getrandom/compare/v0.2.6...v0.2.7
+[0.2.6]: https://github.com/rust-random/getrandom/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/rust-random/getrandom/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/rust-random/getrandom/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/rust-random/getrandom/compare/v0.2.2...v0.2.3

--- a/imports/getrandom/Cargo.lock
+++ b/imports/getrandom/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,16 +44,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.12"
 dependencies = [
  "cfg-if",
  "compiler_builtins",
  "js-sys",
  "libc",
+ "rkyv",
  "rustc-std-workspace-core",
  "wasi",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "xous",
+ "xous-api-names",
+ "xous-ipc",
 ]
 
 [[package]]
@@ -61,9 +77,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -78,6 +94,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,12 +132,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70de01b38fe7baba4ecdd33b777096d2b326993d8ea99bc5b6ede691883d3010"
+dependencies = [
+ "memoffset",
+ "ptr_meta",
+ "rkyv_derive",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a169f6bc5a81033e86ed39d0f4150e2608160b73d2b93c6e8e6a3efa873f14"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -239,4 +326,52 @@ checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "xous"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb93122c9dab77f8bde501ff0677d3df7777982f9faa23603423aeb5eae4e55d"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "xous-api-log"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941f7fd7c114e1e0c401bbbe8222e8adbb4bc8ebeb782f7812d8f1678a578934"
+dependencies = [
+ "log",
+ "num-derive",
+ "num-traits",
+ "xous",
+ "xous-ipc",
+]
+
+[[package]]
+name = "xous-api-names"
+version = "0.9.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "471502d9379d198738ec55dec7cd688ce21e1cfe7d93af6dad25e38c1c404d1c"
+dependencies = [
+ "log",
+ "num-derive",
+ "num-traits",
+ "rkyv",
+ "xous",
+ "xous-api-log",
+ "xous-ipc",
+]
+
+[[package]]
+name = "xous-ipc"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5081581314f115e2005403ee2cc0957d86cbfc49edf6e8b05d2fcf6c226c5d"
+dependencies = [
+ "bitflags",
+ "rkyv",
+ "xous",
 ]

--- a/imports/getrandom/Cargo.toml
+++ b/imports/getrandom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.11" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.12" # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
@@ -18,15 +18,15 @@ compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2.120", default-features = false }
+libc = { version = "0.2.149", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-wasi = "0.11"
+wasi = { version = "0.11", default-features = false }
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.62", default-features = false, optional = true }
 js-sys = { version = "0.3", optional = true }
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3.18"
 
 [target.'cfg(target_os = "xous")'.dependencies]
@@ -41,7 +41,7 @@ rkyv = {version = "0.4.3", default-features = false, features = ["const_generics
 std = []
 # Feature to enable fallback RDRAND-based implementation on x86/x86_64
 rdrand = []
-# Feature to enable JavaScript bindings on wasm32-unknown-unknown
+# Feature to enable JavaScript bindings on wasm*-unknown-unknown
 js = ["wasm-bindgen", "js-sys"]
 # Feature to enable custom RNG implementations
 custom = []
@@ -58,3 +58,14 @@ test-in-browser = []
 [package.metadata.docs.rs]
 features = ["std", "custom"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+# workaround for https://github.com/cross-rs/cross/issues/1345
+[package.metadata.cross.target.x86_64-unknown-netbsd]
+pre-build = [
+    "mkdir -p /tmp/netbsd",
+    "curl https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz -O",
+    "tar -C /tmp/netbsd -xJf base.tar.xz",
+    "cp /tmp/netbsd/usr/lib/libexecinfo.so /usr/local/x86_64-unknown-netbsd/lib",
+    "rm base.tar.xz",
+    "rm -rf /tmp/netbsd",
+]

--- a/imports/getrandom/LICENSE-MIT
+++ b/imports/getrandom/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright 2018 Developers of the Rand project
+Copyright (c) 2018-2024 The rust-random Project Developers
 Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any

--- a/imports/getrandom/README.md
+++ b/imports/getrandom/README.md
@@ -3,7 +3,7 @@
 [![Build Status]][GitHub Actions] [![Crate]][crates.io] [![Documentation]][docs.rs] [![Dependency Status]][deps.rs] [![Downloads]][crates.io] [![License]][LICENSE-MIT]
 
 [GitHub Actions]: https://github.com/rust-random/getrandom/actions?query=workflow:Tests+branch:master
-[Build Status]: https://github.com/rust-random/getrandom/workflows/Tests/badge.svg?branch=master
+[Build Status]: https://github.com/rust-random/getrandom/actions/workflows/tests.yml/badge.svg?branch=master
 [crates.io]: https://crates.io/crates/getrandom
 [Crate]: https://img.shields.io/crates/v/getrandom
 [docs.rs]: https://docs.rs/getrandom
@@ -15,10 +15,10 @@
 [License]: https://img.shields.io/crates/l/getrandom
 
 
-A Rust library for retrieving random data from (operating) system source. It is
-assumed that system always provides high-quality cryptographically secure random
+A Rust library for retrieving random data from (operating) system sources. It is
+assumed that the system always provides high-quality cryptographically secure random
 data, ideally backed by hardware entropy sources. This crate derives its name
-from Linux's `getrandom` function, but is cross platform, roughly supporting
+from Linux's `getrandom` function, but is cross-platform, roughly supporting
 the same set of platforms as Rust's `std` lib.
 
 This is a low-level API. Most users should prefer using high-level random-number
@@ -52,13 +52,30 @@ crate features, WASM support and Custom RNGs see the
 
 ## Minimum Supported Rust Version
 
-This crate requires Rust 1.34.0 or later.
+This crate requires Rust 1.36.0 or later.
 
-# License
+## Platform Support
+
+This crate generally supports the same operating system and platform versions that the Rust standard library does. 
+Additional targets may be supported using pluggable custom implementations.
+
+This means that as Rust drops support for old versions of operating systems (such as old Linux kernel versions, Android API levels, etc)
+in stable releases, `getrandom` may create new patch releases (`0.N.x`) that remove support for outdated platform versions.
+
+## License
 
 The `getrandom` library is distributed under either of
 
- * [Apache License, Version 2.0](LICENSE-APACHE)
- * [MIT license](LICENSE-MIT)
+ * [Apache License, Version 2.0][LICENSE-APACHE]
+ * [MIT license][LICENSE-MIT]
 
 at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[LICENSE-APACHE]: https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/rust-random/getrandom/blob/master/LICENSE-MIT

--- a/imports/getrandom/SECURITY.md
+++ b/imports/getrandom/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at [security advisory](https://github.com/rust-random/getrandom/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.

--- a/imports/getrandom/benches/buffer.rs
+++ b/imports/getrandom/benches/buffer.rs
@@ -1,0 +1,71 @@
+#![feature(test, maybe_uninit_uninit_array_transpose)]
+extern crate test;
+
+use std::mem::MaybeUninit;
+
+// Call getrandom on a zero-initialized stack buffer
+#[inline(always)]
+fn bench_getrandom<const N: usize>() {
+    let mut buf = [0u8; N];
+    getrandom::getrandom(&mut buf).unwrap();
+    test::black_box(&buf as &[u8]);
+}
+
+// Call getrandom_uninit on an uninitialized stack buffer
+#[inline(always)]
+fn bench_getrandom_uninit<const N: usize>() {
+    let mut uninit = [MaybeUninit::uninit(); N];
+    let buf: &[u8] = getrandom::getrandom_uninit(&mut uninit).unwrap();
+    test::black_box(buf);
+}
+
+// We benchmark using #[inline(never)] "inner" functions for two reasons:
+//  - Avoiding inlining reduces a source of variance when running benchmarks.
+//  - It is _much_ easier to get the assembly or IR for the inner loop.
+//
+// For example, using cargo-show-asm (https://github.com/pacak/cargo-show-asm),
+// we can get the assembly for a particular benchmark's inner loop by running:
+//   cargo asm --bench buffer --release buffer::p384::bench_getrandom::inner
+macro_rules! bench {
+    ( $name:ident, $size:expr ) => {
+        pub mod $name {
+            #[bench]
+            pub fn bench_getrandom(b: &mut test::Bencher) {
+                #[inline(never)]
+                fn inner() {
+                    super::bench_getrandom::<{ $size }>()
+                }
+
+                b.bytes = $size as u64;
+                b.iter(inner);
+            }
+            #[bench]
+            pub fn bench_getrandom_uninit(b: &mut test::Bencher) {
+                #[inline(never)]
+                fn inner() {
+                    super::bench_getrandom_uninit::<{ $size }>()
+                }
+
+                b.bytes = $size as u64;
+                b.iter(inner);
+            }
+        }
+    };
+}
+
+// 16 bytes (128 bits) is the size of an 128-bit AES key/nonce.
+bench!(aes128, 128 / 8);
+
+// 32 bytes (256 bits) is the seed sized used for rand::thread_rng
+// and the `random` value in a ClientHello/ServerHello for TLS.
+// This is also the size of a 256-bit AES/HMAC/P-256/Curve25519 key
+// and/or nonce.
+bench!(p256, 256 / 8);
+
+// A P-384/HMAC-384 key and/or nonce.
+bench!(p384, 384 / 8);
+
+// Initializing larger buffers is not the primary use case of this library, as
+// this should normally be done by a userspace CSPRNG. However, we have a test
+// here to see the effects of a lower (amortized) syscall overhead.
+bench!(page, 4096);

--- a/imports/getrandom/src/apple-other.rs
+++ b/imports/getrandom/src/apple-other.rs
@@ -1,0 +1,24 @@
+//! Implementation for iOS, tvOS, and watchOS where `getentropy` is unavailable.
+use crate::Error;
+use core::{ffi::c_void, mem::MaybeUninit};
+
+// libsystem contains the libc of Darwin, and every binary ends up linked against it either way. This
+// makes it a more lightweight choice compared to `Security.framework`.
+extern "C" {
+    // This RNG uses a thread-local CSPRNG to provide data, which is seeded by the operating system's root CSPRNG.
+    // Its the best option after `getentropy` on modern Darwin-based platforms that also avoids the
+    // high startup costs and linking of Security.framework.
+    //
+    // While its just an implementation detail, `Security.framework` just calls into this anyway.
+    fn CCRandomGenerateBytes(bytes: *mut c_void, size: usize) -> i32;
+}
+
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    let ret = unsafe { CCRandomGenerateBytes(dest.as_mut_ptr() as *mut c_void, dest.len()) };
+    // kCCSuccess (from CommonCryptoError.h) is always zero.
+    if ret != 0 {
+        Err(Error::IOS_SEC_RANDOM)
+    } else {
+        Ok(())
+    }
+}

--- a/imports/getrandom/src/bsd_arandom.rs
+++ b/imports/getrandom/src/bsd_arandom.rs
@@ -1,16 +1,11 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for FreeBSD and NetBSD
-use crate::{util_libc::sys_fill_exact, Error};
-use core::ptr;
+use crate::{
+    util_libc::{sys_fill_exact, Weak},
+    Error,
+};
+use core::{mem::MaybeUninit, ptr};
 
-fn kern_arnd(buf: &mut [u8]) -> libc::ssize_t {
+fn kern_arnd(buf: &mut [MaybeUninit<u8>]) -> libc::ssize_t {
     static MIB: [libc::c_int; 2] = [libc::CTL_KERN, libc::KERN_ARND];
     let mut len = buf.len();
     let ret = unsafe {
@@ -30,20 +25,18 @@ fn kern_arnd(buf: &mut [u8]) -> libc::ssize_t {
     }
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    // getrandom(2) was introduced in FreeBSD 12.0 and NetBSD 10.0
-    #[cfg(target_os = "freebsd")]
-    {
-        use crate::util_libc::Weak;
-        static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
-        type GetRandomFn =
-            unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
+type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
 
-        if let Some(fptr) = GETRANDOM.ptr() {
-            let func: GetRandomFn = unsafe { core::mem::transmute(fptr) };
-            return sys_fill_exact(dest, |buf| unsafe { func(buf.as_mut_ptr(), buf.len(), 0) });
-        }
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    // getrandom(2) was introduced in FreeBSD 12.0 and NetBSD 10.0
+    static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
+    if let Some(fptr) = GETRANDOM.ptr() {
+        let func: GetRandomFn = unsafe { core::mem::transmute(fptr) };
+        return sys_fill_exact(dest, |buf| unsafe {
+            func(buf.as_mut_ptr() as *mut u8, buf.len(), 0)
+        });
     }
+
     // Both FreeBSD and NetBSD will only return up to 256 bytes at a time, and
     // older NetBSD kernels will fail on longer buffers.
     for chunk in dest.chunks_mut(256) {

--- a/imports/getrandom/src/custom.rs
+++ b/imports/getrandom/src/custom.rs
@@ -1,14 +1,6 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! An implementation which calls out to an externally defined function.
-use crate::Error;
-use core::num::NonZeroU32;
+use crate::{util::uninit_slice_fill_zero, Error};
+use core::{mem::MaybeUninit, num::NonZeroU32};
 
 /// Register a function to be invoked by `getrandom` on unsupported targets.
 ///
@@ -76,24 +68,36 @@ use core::num::NonZeroU32;
 #[cfg_attr(docsrs, doc(cfg(feature = "custom")))]
 macro_rules! register_custom_getrandom {
     ($path:path) => {
-        // We use an extern "C" function to get the guarantees of a stable ABI.
-        #[no_mangle]
-        extern "C" fn __getrandom_custom(dest: *mut u8, len: usize) -> u32 {
-            let f: fn(&mut [u8]) -> Result<(), ::getrandom::Error> = $path;
-            let slice = unsafe { ::core::slice::from_raw_parts_mut(dest, len) };
-            match f(slice) {
-                Ok(()) => 0,
-                Err(e) => e.code().get(),
+        // TODO(MSRV 1.37): change to unnamed block
+        const __GETRANDOM_INTERNAL: () = {
+            // We use Rust ABI to be safe against potential panics in the passed function.
+            #[no_mangle]
+            unsafe fn __getrandom_custom(dest: *mut u8, len: usize) -> u32 {
+                // Make sure the passed function has the type of getrandom::getrandom
+                type F = fn(&mut [u8]) -> ::core::result::Result<(), $crate::Error>;
+                let _: F = $crate::getrandom;
+                let f: F = $path;
+                let slice = ::core::slice::from_raw_parts_mut(dest, len);
+                match f(slice) {
+                    Ok(()) => 0,
+                    Err(e) => e.code().get(),
+                }
             }
-        }
+        };
     };
 }
 
 #[allow(dead_code)]
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    extern "C" {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    extern "Rust" {
         fn __getrandom_custom(dest: *mut u8, len: usize) -> u32;
     }
+    // Previously we always passed a valid, initialized slice to
+    // `__getrandom_custom`. Ensure `dest` has been initialized for backward
+    // compatibility with implementations that rely on that (e.g. Rust
+    // implementations that construct a `&mut [u8]` slice from `dest` and
+    // `len`).
+    let dest = uninit_slice_fill_zero(dest);
     let ret = unsafe { __getrandom_custom(dest.as_mut_ptr(), dest.len()) };
     match NonZeroU32::new(ret) {
         None => Ok(()),

--- a/imports/getrandom/src/dragonfly.rs
+++ b/imports/getrandom/src/dragonfly.rs
@@ -1,26 +1,21 @@
-// Copyright 2021 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for DragonFly BSD
 use crate::{
     use_file,
     util_libc::{sys_fill_exact, Weak},
     Error,
 };
+use core::mem::MaybeUninit;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
     type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
 
     // getrandom(2) was introduced in DragonflyBSD 5.7
     if let Some(fptr) = GETRANDOM.ptr() {
         let func: GetRandomFn = unsafe { core::mem::transmute(fptr) };
-        return sys_fill_exact(dest, |buf| unsafe { func(buf.as_mut_ptr(), buf.len(), 0) });
+        return sys_fill_exact(dest, |buf| unsafe {
+            func(buf.as_mut_ptr() as *mut u8, buf.len(), 0)
+        });
     } else {
         use_file::getrandom_inner(dest)
     }

--- a/imports/getrandom/src/emscripten.rs
+++ b/imports/getrandom/src/emscripten.rs
@@ -1,0 +1,13 @@
+//! Implementation for Emscripten
+use crate::{util_libc::last_os_error, Error};
+use core::mem::MaybeUninit;
+
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    // Emscripten 2.0.5 added getentropy, so we can use it unconditionally.
+    // Unlike other getentropy implementations, there is no max buffer length.
+    let ret = unsafe { libc::getentropy(dest.as_mut_ptr() as *mut libc::c_void, dest.len()) };
+    if ret < 0 {
+        return Err(last_os_error());
+    }
+    Ok(())
+}

--- a/imports/getrandom/src/error_impls.rs
+++ b/imports/getrandom/src/error_impls.rs
@@ -1,10 +1,3 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 #![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 extern crate std;
 

--- a/imports/getrandom/src/espidf.rs
+++ b/imports/getrandom/src/espidf.rs
@@ -1,20 +1,12 @@
-// Copyright 2021 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for ESP-IDF
 use crate::Error;
-use core::ffi::c_void;
+use core::{ffi::c_void, mem::MaybeUninit};
 
 extern "C" {
     fn esp_fill_random(buf: *mut c_void, len: usize) -> u32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Not that NOT enabling WiFi, BT, or the voltage noise entropy source (via `bootloader_random_enable`)
     // will cause ESP-IDF to return pseudo-random numbers based on the voltage noise entropy, after the initial boot process:
     // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html

--- a/imports/getrandom/src/fuchsia.rs
+++ b/imports/getrandom/src/fuchsia.rs
@@ -1,20 +1,13 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for Fuchsia Zircon
 use crate::Error;
+use core::mem::MaybeUninit;
 
 #[link(name = "zircon")]
 extern "C" {
     fn zx_cprng_draw(buffer: *mut u8, length: usize);
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    unsafe { zx_cprng_draw(dest.as_mut_ptr(), dest.len()) }
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    unsafe { zx_cprng_draw(dest.as_mut_ptr() as *mut u8, dest.len()) }
     Ok(())
 }

--- a/imports/getrandom/src/hermit.rs
+++ b/imports/getrandom/src/hermit.rs
@@ -1,0 +1,29 @@
+//! Implementation for Hermit
+use crate::Error;
+use core::{mem::MaybeUninit, num::NonZeroU32};
+
+/// Minimum return value which we should get from syscalls in practice,
+/// because Hermit uses positive `i32`s for error codes:
+/// https://github.com/hermitcore/libhermit-rs/blob/main/src/errno.rs
+const MIN_RET_CODE: isize = -(i32::MAX as isize);
+
+extern "C" {
+    fn sys_read_entropy(buffer: *mut u8, length: usize, flags: u32) -> isize;
+}
+
+pub fn getrandom_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    while !dest.is_empty() {
+        let res = unsafe { sys_read_entropy(dest.as_mut_ptr() as *mut u8, dest.len(), 0) };
+        // Positive `isize`s can be safely casted to `usize`
+        if res > 0 && (res as usize) <= dest.len() {
+            dest = &mut dest[res as usize..];
+        } else {
+            let err = match res {
+                MIN_RET_CODE..=-1 => NonZeroU32::new(-res as u32).unwrap().into(),
+                _ => Error::UNEXPECTED,
+            };
+            return Err(err);
+        }
+    }
+    Ok(())
+}

--- a/imports/getrandom/src/hurd.rs
+++ b/imports/getrandom/src/hurd.rs
@@ -1,4 +1,4 @@
-//! Implementation for Nintendo 3DS
+//! Implementation for GNU/Hurd
 use crate::util_libc::sys_fill_exact;
 use crate::Error;
 use core::mem::MaybeUninit;

--- a/imports/getrandom/src/js.rs
+++ b/imports/getrandom/src/js.rs
@@ -1,24 +1,21 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
+//! Implementation for WASM based on Web and Node.js
 use crate::Error;
 
 extern crate std;
-use std::thread_local;
+use std::{mem::MaybeUninit, thread_local};
 
-use js_sys::{global, Uint8Array};
+use js_sys::{global, Function, Uint8Array};
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
 
+// Size of our temporary Uint8Array buffer used with WebCrypto methods
 // Maximum is 65536 bytes see https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
-const BROWSER_CRYPTO_BUFFER_SIZE: usize = 256;
+const WEB_CRYPTO_BUFFER_SIZE: usize = 256;
+// Node.js's crypto.randomFillSync requires the size to be less than 2**31.
+const NODE_MAX_BUFFER_SIZE: usize = (1 << 31) - 1;
 
 enum RngSource {
     Node(NodeCrypto),
-    Browser(BrowserCrypto, Uint8Array),
+    Web(WebCrypto, Uint8Array),
 }
 
 // JsValues are always per-thread, so we initialize RngSource for each thread.
@@ -27,20 +24,33 @@ thread_local!(
     static RNG_SOURCE: Result<RngSource, Error> = getrandom_init();
 );
 
-pub(crate) fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub(crate) fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     RNG_SOURCE.with(|result| {
         let source = result.as_ref().map_err(|&e| e)?;
 
         match source {
             RngSource::Node(n) => {
-                if n.random_fill_sync(dest).is_err() {
-                    return Err(Error::NODE_RANDOM_FILL_SYNC);
+                for chunk in dest.chunks_mut(NODE_MAX_BUFFER_SIZE) {
+                    // SAFETY: chunk is never used directly, the memory is only
+                    // modified via the Uint8Array view, which is passed
+                    // directly to JavaScript. Also, crypto.randomFillSync does
+                    // not resize the buffer. We know the length is less than
+                    // u32::MAX because of the chunking above.
+                    // Note that this uses the fact that JavaScript doesn't
+                    // have a notion of "uninitialized memory", this is purely
+                    // a Rust/C/C++ concept.
+                    let res = n.random_fill_sync(unsafe {
+                        Uint8Array::view_mut_raw(chunk.as_mut_ptr() as *mut u8, chunk.len())
+                    });
+                    if res.is_err() {
+                        return Err(Error::NODE_RANDOM_FILL_SYNC);
+                    }
                 }
             }
-            RngSource::Browser(crypto, buf) => {
+            RngSource::Web(crypto, buf) => {
                 // getRandomValues does not work with all types of WASM memory,
                 // so we initially write to browser memory to avoid exceptions.
-                for chunk in dest.chunks_mut(BROWSER_CRYPTO_BUFFER_SIZE) {
+                for chunk in dest.chunks_mut(WEB_CRYPTO_BUFFER_SIZE) {
                     // The chunk can be smaller than buf's length, so we call to
                     // JS to create a smaller view of buf without allocation.
                     let sub_buf = buf.subarray(0, chunk.len() as u32);
@@ -48,7 +58,9 @@ pub(crate) fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
                     if crypto.get_random_values(&sub_buf).is_err() {
                         return Err(Error::WEB_GET_RANDOM_VALUES);
                     }
-                    sub_buf.copy_to(chunk);
+
+                    // SAFETY: `sub_buf`'s length is the same length as `chunk`
+                    unsafe { sub_buf.raw_copy_to_ptr(chunk.as_mut_ptr() as *mut u8) };
                 }
             }
         };
@@ -58,25 +70,33 @@ pub(crate) fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
 
 fn getrandom_init() -> Result<RngSource, Error> {
     let global: Global = global().unchecked_into();
-    if is_node(&global) {
-        let crypto = NODE_MODULE
-            .require("crypto")
-            .map_err(|_| Error::NODE_CRYPTO)?;
-        return Ok(RngSource::Node(crypto));
-    }
 
-    // Assume we are in some Web environment (browser or web worker). We get
-    // `self.crypto` (called `msCrypto` on IE), so we can call
-    // `crypto.getRandomValues`. If `crypto` isn't defined, we assume that
-    // we are in an older web browser and the OS RNG isn't available.
-    let crypto = match (global.crypto(), global.ms_crypto()) {
-        (c, _) if c.is_object() => c,
-        (_, c) if c.is_object() => c,
-        _ => return Err(Error::WEB_CRYPTO),
+    // Get the Web Crypto interface if we are in a browser, Web Worker, Deno,
+    // or another environment that supports the Web Cryptography API. This
+    // also allows for user-provided polyfills in unsupported environments.
+    let crypto = match global.crypto() {
+        // Standard Web Crypto interface
+        c if c.is_object() => c,
+        // Node.js CommonJS Crypto module
+        _ if is_node(&global) => {
+            // If module.require isn't a valid function, we are in an ES module.
+            match Module::require_fn().and_then(JsCast::dyn_into::<Function>) {
+                Ok(require_fn) => match require_fn.call1(&global, &JsValue::from_str("crypto")) {
+                    Ok(n) => return Ok(RngSource::Node(n.unchecked_into())),
+                    Err(_) => return Err(Error::NODE_CRYPTO),
+                },
+                Err(_) => return Err(Error::NODE_ES_MODULE),
+            }
+        }
+        // IE 11 Workaround
+        _ => match global.ms_crypto() {
+            c if c.is_object() => c,
+            _ => return Err(Error::WEB_CRYPTO),
+        },
     };
 
-    let buf = Uint8Array::new_with_length(BROWSER_CRYPTO_BUFFER_SIZE as u32);
-    Ok(RngSource::Browser(crypto, buf))
+    let buf = Uint8Array::new_with_length(WEB_CRYPTO_BUFFER_SIZE as u32);
+    Ok(RngSource::Web(crypto, buf))
 }
 
 // Taken from https://www.npmjs.com/package/browser-or-node
@@ -93,29 +113,35 @@ fn is_node(global: &Global) -> bool {
 
 #[wasm_bindgen]
 extern "C" {
-    type Global; // Return type of js_sys::global()
+    // Return type of js_sys::global()
+    type Global;
 
-    // Web Crypto API (https://www.w3.org/TR/WebCryptoAPI/)
-    #[wasm_bindgen(method, getter, js_name = "msCrypto")]
-    fn ms_crypto(this: &Global) -> BrowserCrypto;
+    // Web Crypto API: Crypto interface (https://www.w3.org/TR/WebCryptoAPI/)
+    type WebCrypto;
+    // Getters for the WebCrypto API
     #[wasm_bindgen(method, getter)]
-    fn crypto(this: &Global) -> BrowserCrypto;
-    type BrowserCrypto;
+    fn crypto(this: &Global) -> WebCrypto;
+    #[wasm_bindgen(method, getter, js_name = msCrypto)]
+    fn ms_crypto(this: &Global) -> WebCrypto;
+    // Crypto.getRandomValues()
     #[wasm_bindgen(method, js_name = getRandomValues, catch)]
-    fn get_random_values(this: &BrowserCrypto, buf: &Uint8Array) -> Result<(), JsValue>;
+    fn get_random_values(this: &WebCrypto, buf: &Uint8Array) -> Result<(), JsValue>;
 
-    // We use a "module" object here instead of just annotating require() with
-    // js_name = "module.require", so that Webpack doesn't give a warning. See:
-    //   https://github.com/rust-random/getrandom/issues/224
-    type NodeModule;
-    #[wasm_bindgen(js_name = module)]
-    static NODE_MODULE: NodeModule;
     // Node JS crypto module (https://nodejs.org/api/crypto.html)
-    #[wasm_bindgen(method, catch)]
-    fn require(this: &NodeModule, s: &str) -> Result<NodeCrypto, JsValue>;
     type NodeCrypto;
+    // crypto.randomFillSync()
     #[wasm_bindgen(method, js_name = randomFillSync, catch)]
-    fn random_fill_sync(this: &NodeCrypto, buf: &mut [u8]) -> Result<(), JsValue>;
+    fn random_fill_sync(this: &NodeCrypto, buf: Uint8Array) -> Result<(), JsValue>;
+
+    // Ideally, we would just use `fn require(s: &str)` here. However, doing
+    // this causes a Webpack warning. So we instead return the function itself
+    // and manually invoke it using call1. This also lets us to check that the
+    // function actually exists, allowing for better error messages. See:
+    //   https://github.com/rust-random/getrandom/issues/224
+    //   https://github.com/rust-random/getrandom/issues/256
+    type Module;
+    #[wasm_bindgen(getter, static_method_of = Module, js_class = module, js_name = require, catch)]
+    fn require_fn() -> Result<JsValue, JsValue>;
 
     // Node JS process Object (https://nodejs.org/api/process.html)
     #[wasm_bindgen(method, getter)]

--- a/imports/getrandom/src/lazy.rs
+++ b/imports/getrandom/src/lazy.rs
@@ -1,0 +1,56 @@
+use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+// This structure represents a lazily initialized static usize value. Useful
+// when it is preferable to just rerun initialization instead of locking.
+// Both unsync_init and sync_init will invoke an init() function until it
+// succeeds, then return the cached value for future calls.
+//
+// Both methods support init() "failing". If the init() method returns UNINIT,
+// that value will be returned as normal, but will not be cached.
+//
+// Users should only depend on the _value_ returned by init() functions.
+// Specifically, for the following init() function:
+//      fn init() -> usize {
+//          a();
+//          let v = b();
+//          c();
+//          v
+//      }
+// the effects of c() or writes to shared memory will not necessarily be
+// observed and additional synchronization methods with be needed.
+pub(crate) struct LazyUsize(AtomicUsize);
+
+impl LazyUsize {
+    pub const fn new() -> Self {
+        Self(AtomicUsize::new(Self::UNINIT))
+    }
+
+    // The initialization is not completed.
+    pub const UNINIT: usize = usize::max_value();
+
+    // Runs the init() function at least once, returning the value of some run
+    // of init(). Multiple callers can run their init() functions in parallel.
+    // init() should always return the same value, if it succeeds.
+    pub fn unsync_init(&self, init: impl FnOnce() -> usize) -> usize {
+        // Relaxed ordering is fine, as we only have a single atomic variable.
+        let mut val = self.0.load(Relaxed);
+        if val == Self::UNINIT {
+            val = init();
+            self.0.store(val, Relaxed);
+        }
+        val
+    }
+}
+
+// Identical to LazyUsize except with bool instead of usize.
+pub(crate) struct LazyBool(LazyUsize);
+
+impl LazyBool {
+    pub const fn new() -> Self {
+        Self(LazyUsize::new())
+    }
+
+    pub fn unsync_init(&self, init: impl FnOnce() -> bool) -> bool {
+        self.0.unsync_init(|| init() as usize) != 0
+    }
+}

--- a/imports/getrandom/src/lib.rs
+++ b/imports/getrandom/src/lib.rs
@@ -1,11 +1,3 @@
-// Copyright 2019 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Interface to the operating system's random number generator.
 //!
 //! # Supported targets
@@ -14,26 +6,29 @@
 //! | ----------------- | ------------------ | --------------
 //! | Linux, Android    | `*‑linux‑*`        | [`getrandom`][1] system call if available, otherwise [`/dev/urandom`][2] after successfully polling `/dev/random`
 //! | Windows           | `*‑windows‑*`      | [`BCryptGenRandom`]
-//! | macOS             | `*‑apple‑darwin`   | [`getentropy`][3] if available, otherwise [`/dev/random`][4] (identical to `/dev/urandom`)
-//! | iOS               | `*‑apple‑ios`      | [`SecRandomCopyBytes`]
+//! | macOS             | `*‑apple‑darwin`   | [`getentropy`][3]
+//! | iOS, tvOS, watchOS | `*‑apple‑ios`, `*-apple-tvos`, `*-apple-watchos` | [`CCRandomGenerateBytes`]
 //! | FreeBSD           | `*‑freebsd`        | [`getrandom`][5] if available, otherwise [`kern.arandom`][6]
 //! | OpenBSD           | `*‑openbsd`        | [`getentropy`][7]
-//! | NetBSD            | `*‑netbsd`         | [`kern.arandom`][8]
-//! | Dragonfly BSD     | `*‑dragonfly`      | [`getrandom`][9] if available, otherwise [`/dev/random`][10]
+//! | NetBSD            | `*‑netbsd`         | [`getrandom`][16] if available, otherwise [`kern.arandom`][8]
+//! | Dragonfly BSD     | `*‑dragonfly`      | [`getrandom`][9] if available, otherwise [`/dev/urandom`][10] (identical to `/dev/random`)
 //! | Solaris, illumos  | `*‑solaris`, `*‑illumos` | [`getrandom`][11] if available, otherwise [`/dev/random`][12]
 //! | Fuchsia OS        | `*‑fuchsia`        | [`cprng_draw`]
 //! | Redox             | `*‑redox`          | `/dev/urandom`
-//! | Haiku             | `*‑haiku`          | `/dev/random` (identical to `/dev/urandom`)
-//! | Hermit            | `x86_64-*-hermit`  | [`RDRAND`]
+//! | Haiku             | `*‑haiku`          | `/dev/urandom` (identical to `/dev/random`)
+//! | Hermit            | `*-hermit`         | [`sys_read_entropy`]
+//! | Hurd              | `*-hurd-*`         | [`getrandom`][17]
 //! | SGX               | `x86_64‑*‑sgx`     | [`RDRAND`]
 //! | VxWorks           | `*‑wrs‑vxworks‑*`  | `randABytes` after checking entropy pool initialization with `randSecure`
 //! | ESP-IDF           | `*‑espidf`         | [`esp_fill_random`]
-//! | Emscripten        | `*‑emscripten`     | `/dev/random` (identical to `/dev/urandom`)
+//! | Emscripten        | `*‑emscripten`     | [`getentropy`][13]
 //! | WASI              | `wasm32‑wasi`      | [`random_get`]
-//! | Web Browser       | `wasm32‑*‑unknown` | [`Crypto.getRandomValues`], see [WebAssembly support]
-//! | Node.js           | `wasm32‑*‑unknown` | [`crypto.randomBytes`], see [WebAssembly support]
+//! | Web Browser and Node.js | `wasm*‑*‑unknown` | [`Crypto.getRandomValues`] if available, then [`crypto.randomFillSync`] if on Node.js, see [WebAssembly support]
 //! | SOLID             | `*-kmc-solid_*`    | `SOLID_RNG_SampleRandomBytes`
 //! | Nintendo 3DS      | `armv6k-nintendo-3ds` | [`getrandom`][1]
+//! | PS Vita           | `armv7-sony-vita-newlibeabihf` | [`getentropy`][13]
+//! | QNX Neutrino      | `*‑nto-qnx*`          | [`/dev/urandom`][14] (identical to `/dev/random`)
+//! | AIX               | `*-ibm-aix`        | [`/dev/urandom`][15]
 //! | Xous              | `riscv32imac-unknown-xous-elf` | [`trng`]
 //!
 //! There is no blanket implementation on `unix` targets that reads from
@@ -73,10 +68,43 @@
 //! that you are building for an environment containing JavaScript, and will
 //! call the appropriate methods. Both web browser (main window and Web Workers)
 //! and Node.js environments are supported, invoking the methods
-//! [described above](#supported-targets) using the
-//! [wasm-bindgen](https://github.com/rust-lang/rust-bindgen) toolchain.
+//! [described above](#supported-targets) using the [`wasm-bindgen`] toolchain.
+//!
+//! To enable the `js` Cargo feature, add the following to the `dependencies`
+//! section in your `Cargo.toml` file:
+//! ```toml
+//! [dependencies]
+//! getrandom = { version = "0.2", features = ["js"] }
+//! ```
+//!
+//! This can be done even if `getrandom` is not a direct dependency. Cargo
+//! allows crates to enable features for indirect dependencies.
+//!
+//! This feature should only be enabled for binary, test, or benchmark crates.
+//! Library crates should generally not enable this feature, leaving such a
+//! decision to *users* of their library. Also, libraries should not introduce
+//! their own `js` features *just* to enable `getrandom`'s `js` feature.
 //!
 //! This feature has no effect on targets other than `wasm32-unknown-unknown`.
+//!
+//! #### Node.js ES module support
+//!
+//! Node.js supports both [CommonJS modules] and [ES modules]. Due to
+//! limitations in wasm-bindgen's [`module`] support, we cannot directly
+//! support ES Modules running on Node.js. However, on Node v15 and later, the
+//! module author can add a simple shim to support the Web Cryptography API:
+//! ```js
+//! import { webcrypto } from 'node:crypto'
+//! globalThis.crypto = webcrypto
+//! ```
+//! This crate will then use the provided `webcrypto` implementation.
+//!
+//! ### Platform Support
+//! This crate generally supports the same operating system and platform versions that the Rust standard library does.
+//! Additional targets may be supported using pluggable custom implementations.
+//!
+//! This means that as Rust drops support for old versions of operating systems (such as old Linux kernel versions, Android API levels, etc)
+//! in stable releases, `getrandom` may create new patch releases (`0.N.x`) that remove support for outdated platform versions.
 //!
 //! ### Custom implementations
 //!
@@ -89,16 +117,6 @@
 //! that would otherwise not compile. Any supported targets (including those
 //! using `rdrand` and `js` Cargo features) continue using their normal
 //! implementations even if a function is registered.
-//!
-//! ### Indirect Dependencies
-//!
-//! If `getrandom` is not a direct dependency of your crate, you can still
-//! enable any of the above fallback behaviors by enabling the relevant
-//! feature in your root crate's `Cargo.toml`:
-//! ```toml
-//! [dependencies]
-//! getrandom = { version = "0.2", features = ["js"] }
-//! ```
 //!
 //! ## Early boot
 //!
@@ -116,18 +134,27 @@
 //! entropy yet. To avoid returning low-entropy bytes, we first poll
 //! `/dev/random` and only switch to `/dev/urandom` once this has succeeded.
 //!
+//! On OpenBSD, this kind of entropy accounting isn't available, and on
+//! NetBSD, blocking on it is discouraged. On these platforms, nonblocking
+//! interfaces are used, even when reliable entropy may not be available.
+//! On the platforms where it is used, the reliability of entropy accounting
+//! itself isn't free from controversy. This library provides randomness
+//! sourced according to the platform's best practices, but each platform has
+//! its own limits on the grade of randomness it can promise in environments
+//! with few sources of entropy.
+//!
 //! ## Error handling
 //!
-//! We always choose failure over returning insecure "random" bytes. In general,
-//! on supported platforms, failure is highly unlikely, though not impossible.
-//! If an error does occur, then it is likely that it will occur on every call to
-//! `getrandom`, hence after the first successful call one can be reasonably
-//! confident that no errors will occur.
+//! We always choose failure over returning known insecure "random" bytes. In
+//! general, on supported platforms, failure is highly unlikely, though not
+//! impossible. If an error does occur, then it is likely that it will occur
+//! on every call to `getrandom`, hence after the first successful call one
+//! can be reasonably confident that no errors will occur.
 //!
 //! [1]: http://man7.org/linux/man-pages/man2/getrandom.2.html
 //! [2]: http://man7.org/linux/man-pages/man4/urandom.4.html
 //! [3]: https://www.unix.com/man-page/mojave/2/getentropy/
-//! [4]: https://www.unix.com/man-page/mojave/4/random/
+//! [4]: https://www.unix.com/man-page/mojave/4/urandom/
 //! [5]: https://www.freebsd.org/cgi/man.cgi?query=getrandom&manpath=FreeBSD+12.0-stable
 //! [6]: https://www.freebsd.org/cgi/man.cgi?query=random&sektion=4
 //! [7]: https://man.openbsd.org/getentropy.2
@@ -136,21 +163,31 @@
 //! [10]: https://leaf.dragonflybsd.org/cgi/web-man?command=random&section=4
 //! [11]: https://docs.oracle.com/cd/E88353_01/html/E37841/getrandom-2.html
 //! [12]: https://docs.oracle.com/cd/E86824_01/html/E54777/random-7d.html
+//! [13]: https://github.com/emscripten-core/emscripten/pull/12240
+//! [14]: https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.utilities/topic/r/random.html
+//! [15]: https://www.ibm.com/docs/en/aix/7.3?topic=files-random-urandom-devices
+//! [16]: https://man.netbsd.org/getrandom.2
+//! [17]: https://www.gnu.org/software/libc/manual/html_mono/libc.html#index-getrandom
 //!
 //! [`BCryptGenRandom`]: https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom
 //! [`Crypto.getRandomValues`]: https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
 //! [`RDRAND`]: https://software.intel.com/en-us/articles/intel-digital-random-number-generator-drng-software-implementation-guide
-//! [`SecRandomCopyBytes`]: https://developer.apple.com/documentation/security/1399291-secrandomcopybytes?language=objc
+//! [`CCRandomGenerateBytes`]: https://opensource.apple.com/source/CommonCrypto/CommonCrypto-60074/include/CommonRandom.h.auto.html
 //! [`cprng_draw`]: https://fuchsia.dev/fuchsia-src/zircon/syscalls/cprng_draw
-//! [`crypto.randomBytes`]: https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback
+//! [`crypto.randomFillSync`]: https://nodejs.org/api/crypto.html#cryptorandomfillsyncbuffer-offset-size
 //! [`esp_fill_random`]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html#_CPPv415esp_fill_randomPv6size_t
 //! [`random_get`]: https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#-random_getbuf-pointeru8-buf_len-size---errno
 //! [WebAssembly support]: #webassembly-support
+//! [`wasm-bindgen`]: https://github.com/rustwasm/wasm-bindgen
+//! [`module`]: https://rustwasm.github.io/wasm-bindgen/reference/attributes/on-js-imports/module.html
+//! [CommonJS modules]: https://nodejs.org/api/modules.html
+//! [ES modules]: https://nodejs.org/api/esm.html
+//! [`sys_read_entropy`]: https://github.com/hermit-os/kernel/blob/315f58ff5efc81d9bf0618af85a59963ff55f8b1/src/syscalls/entropy.rs#L47-L55
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getrandom/0.2.11"
+    html_root_url = "https://docs.rs/getrandom/0.2.12"
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]
@@ -158,6 +195,9 @@
 
 #[macro_use]
 extern crate cfg_if;
+
+use crate::util::{slice_as_uninit_mut, slice_assume_init_mut};
+use core::mem::MaybeUninit;
 
 mod error;
 mod util;
@@ -172,15 +212,19 @@ pub use crate::error::Error;
 
 // System-specific implementations.
 //
-// These should all provide getrandom_inner with the same signature as getrandom.
+// These should all provide getrandom_inner with the signature
+// `fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error>`.
+// The function MUST fully initialize `dest` when `Ok(())` is returned.
+// The function MUST NOT ever write uninitialized bytes into `dest`,
+// regardless of what value it returns.
 cfg_if! {
-    if #[cfg(any(target_os = "emscripten", target_os = "haiku",
-                 target_os = "redox"))] {
+    if #[cfg(any(target_os = "haiku", target_os = "redox", target_os = "nto", target_os = "aix"))] {
         mod util_libc;
         #[path = "use_file.rs"] mod imp;
     } else if #[cfg(any(target_os = "android", target_os = "linux"))] {
         mod util_libc;
         mod use_file;
+        mod lazy;
         #[path = "linux_android.rs"] mod imp;
     } else if #[cfg(any(target_os = "illumos", target_os = "solaris"))] {
         mod util_libc;
@@ -195,19 +239,18 @@ cfg_if! {
         #[path = "dragonfly.rs"] mod imp;
     } else if #[cfg(target_os = "fuchsia")] {
         #[path = "fuchsia.rs"] mod imp;
-    } else if #[cfg(target_os = "ios")] {
-        #[path = "ios.rs"] mod imp;
+    } else if #[cfg(any(target_os = "ios", target_os = "watchos", target_os = "tvos"))] {
+        #[path = "apple-other.rs"] mod imp;
     } else if #[cfg(target_os = "macos")] {
         mod util_libc;
-        mod use_file;
         #[path = "macos.rs"] mod imp;
     } else if #[cfg(target_os = "openbsd")] {
         mod util_libc;
         #[path = "openbsd.rs"] mod imp;
-    } else if #[cfg(target_os = "wasi")] {
+    } else if #[cfg(all(target_arch = "wasm32", target_os = "wasi"))] {
         #[path = "wasi.rs"] mod imp;
-    } else if #[cfg(all(target_arch = "x86_64", target_os = "hermit"))] {
-        #[path = "rdrand.rs"] mod imp;
+    } else if #[cfg(target_os = "hermit")] {
+        #[path = "hermit.rs"] mod imp;
     } else if #[cfg(target_os = "vxworks")] {
         mod util_libc;
         #[path = "vxworks.rs"] mod imp;
@@ -217,25 +260,38 @@ cfg_if! {
         #[path = "espidf.rs"] mod imp;
     } else if #[cfg(windows)] {
         #[path = "windows.rs"] mod imp;
-    } else if #[cfg(all(target_arch = "x86_64", target_env = "sgx"))] {
-        #[path = "rdrand.rs"] mod imp;
-    } else if #[cfg(all(feature = "rdrand",
-                        any(target_arch = "x86_64", target_arch = "x86")))] {
-        #[path = "rdrand.rs"] mod imp;
-    } else if #[cfg(all(feature = "js",
-                        target_arch = "wasm32", target_os = "unknown"))] {
-        #[path = "js.rs"] mod imp;
     } else if #[cfg(all(target_os = "horizon", target_arch = "arm"))] {
         // We check for target_arch = "arm" because the Nintendo Switch also
         // uses Horizon OS (it is aarch64).
         mod util_libc;
         #[path = "3ds.rs"] mod imp;
+    } else if #[cfg(target_os = "vita")] {
+        mod util_libc;
+        #[path = "vita.rs"] mod imp;
+    } else if #[cfg(target_os = "emscripten")] {
+        mod util_libc;
+        #[path = "emscripten.rs"] mod imp;
+    } else if #[cfg(all(target_arch = "x86_64", target_env = "sgx"))] {
+        mod lazy;
+        #[path = "rdrand.rs"] mod imp;
+    } else if #[cfg(all(feature = "rdrand",
+                        any(target_arch = "x86_64", target_arch = "x86")))] {
+        mod lazy;
+        #[path = "rdrand.rs"] mod imp;
+    } else if #[cfg(all(feature = "js",
+                        any(target_arch = "wasm32", target_arch = "wasm64"),
+                        target_os = "unknown"))] {
+        #[path = "js.rs"] mod imp;
+    } else if #[cfg(target_os = "hurd")] {
+        mod util_libc;
+        #[path = "hurd.rs"] mod imp;
     } else if #[cfg(target_os = "xous")] {
         #[path = "xous.rs"] mod imp;
     } else if #[cfg(feature = "custom")] {
         use custom as imp;
-    } else if #[cfg(all(target_arch = "wasm32", target_os = "unknown"))] {
-        compile_error!("the wasm32-unknown-unknown target is not supported by \
+    } else if #[cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"),
+                        target_os = "unknown"))] {
+        compile_error!("the wasm*-unknown-unknown targets are not supported by \
                         default, you may need to enable the \"js\" feature. \
                         For more information see: \
                         https://docs.rs/getrandom/#webassembly-support");
@@ -258,9 +314,42 @@ cfg_if! {
 /// In general, `getrandom` will be fast enough for interactive usage, though
 /// significantly slower than a user-space CSPRNG; for the latter consider
 /// [`rand::thread_rng`](https://docs.rs/rand/*/rand/fn.thread_rng.html).
+#[inline]
 pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
-    if dest.is_empty() {
-        return Ok(());
+    // SAFETY: The `&mut MaybeUninit<_>` reference doesn't escape, and
+    // `getrandom_uninit` guarantees it will never de-initialize any part of
+    // `dest`.
+    getrandom_uninit(unsafe { slice_as_uninit_mut(dest) })?;
+    Ok(())
+}
+
+/// Version of the `getrandom` function which fills `dest` with random bytes
+/// returns a mutable reference to those bytes.
+///
+/// On successful completion this function is guaranteed to return a slice
+/// which points to the same memory as `dest` and has the same length.
+/// In other words, it's safe to assume that `dest` is initialized after
+/// this function has returned `Ok`.
+///
+/// No part of `dest` will ever be de-initialized at any point, regardless
+/// of what is returned.
+///
+/// # Examples
+///
+/// ```ignore
+/// # // We ignore this test since `uninit_array` is unstable.
+/// #![feature(maybe_uninit_uninit_array)]
+/// # fn main() -> Result<(), getrandom::Error> {
+/// let mut buf = core::mem::MaybeUninit::uninit_array::<1024>();
+/// let buf: &mut [u8] = getrandom::getrandom_uninit(&mut buf)?;
+/// # Ok(()) }
+/// ```
+#[inline]
+pub fn getrandom_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<&mut [u8], Error> {
+    if !dest.is_empty() {
+        imp::getrandom_inner(dest)?;
     }
-    imp::getrandom_inner(dest)
+    // SAFETY: `dest` has been fully initialized by `imp::getrandom_inner`
+    // since it returned `Ok`.
+    Ok(unsafe { slice_assume_init_mut(dest) })
 }

--- a/imports/getrandom/src/linux_android.rs
+++ b/imports/getrandom/src/linux_android.rs
@@ -1,19 +1,12 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for Linux / Android
 use crate::{
-    util::LazyBool,
+    lazy::LazyBool,
     util_libc::{last_os_error, sys_fill_exact},
     {use_file, Error},
 };
+use core::mem::MaybeUninit;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getrandom(2) was introduced in Linux 3.17
     static HAS_GETRANDOM: LazyBool = LazyBool::new();
     if HAS_GETRANDOM.unsync_init(is_getrandom_available) {

--- a/imports/getrandom/src/openbsd.rs
+++ b/imports/getrandom/src/openbsd.rs
@@ -1,15 +1,8 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for OpenBSD
 use crate::{util_libc::last_os_error, Error};
+use core::mem::MaybeUninit;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getentropy(2) was added in OpenBSD 5.6, so we can use it unconditionally.
     for chunk in dest.chunks_mut(256) {
         let ret = unsafe { libc::getentropy(chunk.as_mut_ptr() as *mut libc::c_void, chunk.len()) };

--- a/imports/getrandom/src/rdrand.rs
+++ b/imports/getrandom/src/rdrand.rs
@@ -1,14 +1,6 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
-//! Implementation for SGX using RDRAND instruction
-use crate::Error;
-use core::mem;
+//! RDRAND backend for x86(-64) targets
+use crate::{lazy::LazyBool, util::slice_as_uninit, Error};
+use core::mem::{size_of, MaybeUninit};
 
 cfg_if! {
     if #[cfg(target_arch = "x86_64")] {
@@ -24,74 +16,106 @@ cfg_if! {
 // Implementation Guide" - Section 5.2.1 and "Intel® 64 and IA-32 Architectures
 // Software Developer’s Manual" - Volume 1 - Section 7.3.17.1.
 const RETRY_LIMIT: usize = 10;
-const WORD_SIZE: usize = mem::size_of::<usize>();
 
 #[target_feature(enable = "rdrand")]
-unsafe fn rdrand() -> Result<[u8; WORD_SIZE], Error> {
+unsafe fn rdrand() -> Option<usize> {
     for _ in 0..RETRY_LIMIT {
-        let mut el = mem::zeroed();
-        if rdrand_step(&mut el) == 1 {
-            // AMD CPUs from families 14h to 16h (pre Ryzen) sometimes fail to
-            // set CF on bogus random data, so we check these values explicitly.
-            // See https://github.com/systemd/systemd/issues/11810#issuecomment-489727505
-            // We perform this check regardless of target to guard against
-            // any implementation that incorrectly fails to set CF.
-            if el != 0 && el != !0 {
-                return Ok(el.to_ne_bytes());
-            }
-            // Keep looping in case this was a false positive.
+        let mut val = 0;
+        if rdrand_step(&mut val) == 1 {
+            return Some(val as usize);
         }
     }
-    Err(Error::FAILED_RDRAND)
+    None
 }
 
-// "rdrand" target feature requires "+rdrnd" flag, see https://github.com/rust-lang/rust/issues/49653.
+// "rdrand" target feature requires "+rdrand" flag, see https://github.com/rust-lang/rust/issues/49653.
 #[cfg(all(target_env = "sgx", not(target_feature = "rdrand")))]
 compile_error!(
-    "SGX targets require 'rdrand' target feature. Enable by using -C target-feature=+rdrnd."
+    "SGX targets require 'rdrand' target feature. Enable by using -C target-feature=+rdrand."
 );
 
-#[cfg(target_feature = "rdrand")]
-fn is_rdrand_supported() -> bool {
-    true
+// Run a small self-test to make sure we aren't repeating values
+// Adapted from Linux's test in arch/x86/kernel/cpu/rdrand.c
+// Fails with probability < 2^(-90) on 32-bit systems
+#[target_feature(enable = "rdrand")]
+unsafe fn self_test() -> bool {
+    // On AMD, RDRAND returns 0xFF...FF on failure, count it as a collision.
+    let mut prev = !0; // TODO(MSRV 1.43): Move to usize::MAX
+    let mut fails = 0;
+    for _ in 0..8 {
+        match rdrand() {
+            Some(val) if val == prev => fails += 1,
+            Some(val) => prev = val,
+            None => return false,
+        };
+    }
+    fails <= 2
 }
 
-// TODO use is_x86_feature_detected!("rdrand") when that works in core. See:
-// https://github.com/rust-lang-nursery/stdsimd/issues/464
-#[cfg(not(target_feature = "rdrand"))]
-fn is_rdrand_supported() -> bool {
-    use crate::util::LazyBool;
+fn is_rdrand_good() -> bool {
+    #[cfg(not(target_feature = "rdrand"))]
+    {
+        // SAFETY: All Rust x86 targets are new enough to have CPUID, and we
+        // check that leaf 1 is supported before using it.
+        let cpuid0 = unsafe { arch::__cpuid(0) };
+        if cpuid0.eax < 1 {
+            return false;
+        }
+        let cpuid1 = unsafe { arch::__cpuid(1) };
 
-    // SAFETY: All Rust x86 targets are new enough to have CPUID, and if CPUID
-    // is supported, CPUID leaf 1 is always supported.
-    const FLAG: u32 = 1 << 30;
-    static HAS_RDRAND: LazyBool = LazyBool::new();
-    HAS_RDRAND.unsync_init(|| unsafe { (arch::__cpuid(1).ecx & FLAG) != 0 })
-}
+        let vendor_id = [
+            cpuid0.ebx.to_le_bytes(),
+            cpuid0.edx.to_le_bytes(),
+            cpuid0.ecx.to_le_bytes(),
+        ];
+        if vendor_id == [*b"Auth", *b"enti", *b"cAMD"] {
+            let mut family = (cpuid1.eax >> 8) & 0xF;
+            if family == 0xF {
+                family += (cpuid1.eax >> 20) & 0xFF;
+            }
+            // AMD CPUs families before 17h (Zen) sometimes fail to set CF when
+            // RDRAND fails after suspend. Don't use RDRAND on those families.
+            // See https://bugzilla.redhat.com/show_bug.cgi?id=1150286
+            if family < 0x17 {
+                return false;
+            }
+        }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    if !is_rdrand_supported() {
-        return Err(Error::NO_RDRAND);
+        const RDRAND_FLAG: u32 = 1 << 30;
+        if cpuid1.ecx & RDRAND_FLAG == 0 {
+            return false;
+        }
     }
 
-    // SAFETY: After this point, rdrand is supported, so calling the rdrand
-    // functions is not undefined behavior.
-    unsafe { rdrand_exact(dest) }
+    // SAFETY: We have already checked that rdrand is available.
+    unsafe { self_test() }
 }
 
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    static RDRAND_GOOD: LazyBool = LazyBool::new();
+    if !RDRAND_GOOD.unsync_init(is_rdrand_good) {
+        return Err(Error::NO_RDRAND);
+    }
+    // SAFETY: After this point, we know rdrand is supported.
+    unsafe { rdrand_exact(dest) }.ok_or(Error::FAILED_RDRAND)
+}
+
+// TODO: make this function safe when we have feature(target_feature_11)
 #[target_feature(enable = "rdrand")]
-unsafe fn rdrand_exact(dest: &mut [u8]) -> Result<(), Error> {
+unsafe fn rdrand_exact(dest: &mut [MaybeUninit<u8>]) -> Option<()> {
     // We use chunks_exact_mut instead of chunks_mut as it allows almost all
     // calls to memcpy to be elided by the compiler.
-    let mut chunks = dest.chunks_exact_mut(WORD_SIZE);
+    let mut chunks = dest.chunks_exact_mut(size_of::<usize>());
     for chunk in chunks.by_ref() {
-        chunk.copy_from_slice(&rdrand()?);
+        let src = rdrand()?.to_ne_bytes();
+        chunk.copy_from_slice(slice_as_uninit(&src));
     }
 
     let tail = chunks.into_remainder();
     let n = tail.len();
     if n > 0 {
-        tail.copy_from_slice(&rdrand()?[..n]);
+        let src = rdrand()?.to_ne_bytes();
+        tail.copy_from_slice(slice_as_uninit(&src[..n]));
     }
-    Ok(())
+    Some(())
 }

--- a/imports/getrandom/src/solaris_illumos.rs
+++ b/imports/getrandom/src/solaris_illumos.rs
@@ -1,19 +1,10 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for the Solaris family
 //!
-//! Read from `/dev/random`, with chunks of limited size (256 bytes).
 //! `/dev/random` uses the Hash_DRBG with SHA512 algorithm from NIST SP 800-90A.
 //! `/dev/urandom` uses the FIPS 186-2 algorithm, which is considered less
-//! secure. We choose to read from `/dev/random`.
+//! secure. We choose to read from `/dev/random` (and use GRND_RANDOM).
 //!
-//! Since Solaris 11.3 and mid-2015 illumos, the `getrandom` syscall is available.
+//! Solaris 11.3 and late-2018 illumos added the getrandom(2) libc function.
 //! To make sure we can compile on both Solaris and its derivatives, as well as
 //! function, we check for the existence of getrandom(2) in libc by calling
 //! libc::dlsym.
@@ -22,23 +13,25 @@ use crate::{
     util_libc::{sys_fill_exact, Weak},
     Error,
 };
-use core::mem;
+use core::mem::{self, MaybeUninit};
 
-#[cfg(target_os = "illumos")]
-type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
-#[cfg(target_os = "solaris")]
-type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::c_int;
+static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
+type GetRandomFn =
+    unsafe extern "C" fn(*mut libc::c_void, libc::size_t, libc::c_uint) -> libc::ssize_t;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    // getrandom(2) was introduced in Solaris 11.3 for Illumos in 2015.
-    static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     if let Some(fptr) = GETRANDOM.ptr() {
         let func: GetRandomFn = unsafe { mem::transmute(fptr) };
         // 256 bytes is the lowest common denominator across all the Solaris
         // derived platforms for atomically obtaining random data.
         for chunk in dest.chunks_mut(256) {
             sys_fill_exact(chunk, |buf| unsafe {
-                func(buf.as_mut_ptr(), buf.len(), 0) as libc::ssize_t
+                // A cast is needed for the flags as libc uses the wrong type.
+                func(
+                    buf.as_mut_ptr() as *mut libc::c_void,
+                    buf.len(),
+                    libc::GRND_RANDOM as libc::c_uint,
+                )
             })?
         }
         Ok(())

--- a/imports/getrandom/src/solid.rs
+++ b/imports/getrandom/src/solid.rs
@@ -1,21 +1,13 @@
-// Copyright 2021 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for SOLID
 use crate::Error;
-use core::num::NonZeroU32;
+use core::{mem::MaybeUninit, num::NonZeroU32};
 
 extern "C" {
     pub fn SOLID_RNG_SampleRandomBytes(buffer: *mut u8, length: usize) -> i32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr(), dest.len()) };
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr() as *mut u8, dest.len()) };
     if ret >= 0 {
         Ok(())
     } else {

--- a/imports/getrandom/src/util.rs
+++ b/imports/getrandom/src/util.rs
@@ -1,64 +1,35 @@
-// Copyright 2019 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 #![allow(dead_code)]
-use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use core::{mem::MaybeUninit, ptr};
 
-// This structure represents a lazily initialized static usize value. Useful
-// when it is preferable to just rerun initialization instead of locking.
-// Both unsync_init and sync_init will invoke an init() function until it
-// succeeds, then return the cached value for future calls.
-//
-// Both methods support init() "failing". If the init() method returns UNINIT,
-// that value will be returned as normal, but will not be cached.
-//
-// Users should only depend on the _value_ returned by init() functions.
-// Specifically, for the following init() function:
-//      fn init() -> usize {
-//          a();
-//          let v = b();
-//          c();
-//          v
-//      }
-// the effects of c() or writes to shared memory will not necessarily be
-// observed and additional synchronization methods with be needed.
-pub struct LazyUsize(AtomicUsize);
-
-impl LazyUsize {
-    pub const fn new() -> Self {
-        Self(AtomicUsize::new(Self::UNINIT))
-    }
-
-    // The initialization is not completed.
-    pub const UNINIT: usize = usize::max_value();
-
-    // Runs the init() function at least once, returning the value of some run
-    // of init(). Multiple callers can run their init() functions in parallel.
-    // init() should always return the same value, if it succeeds.
-    pub fn unsync_init(&self, init: impl FnOnce() -> usize) -> usize {
-        // Relaxed ordering is fine, as we only have a single atomic variable.
-        let mut val = self.0.load(Relaxed);
-        if val == Self::UNINIT {
-            val = init();
-            self.0.store(val, Relaxed);
-        }
-        val
-    }
+/// Polyfill for `maybe_uninit_slice` feature's
+/// `MaybeUninit::slice_assume_init_mut`. Every element of `slice` must have
+/// been initialized.
+#[inline(always)]
+pub unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
+    // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
+    &mut *(slice as *mut [MaybeUninit<T>] as *mut [T])
 }
 
-// Identical to LazyUsize except with bool instead of usize.
-pub struct LazyBool(LazyUsize);
+#[inline]
+pub fn uninit_slice_fill_zero(slice: &mut [MaybeUninit<u8>]) -> &mut [u8] {
+    unsafe { ptr::write_bytes(slice.as_mut_ptr(), 0, slice.len()) };
+    unsafe { slice_assume_init_mut(slice) }
+}
 
-impl LazyBool {
-    pub const fn new() -> Self {
-        Self(LazyUsize::new())
-    }
+#[inline(always)]
+pub fn slice_as_uninit<T>(slice: &[T]) -> &[MaybeUninit<T>] {
+    // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
+    // There is no risk of writing a `MaybeUninit<T>` into the result since
+    // the result isn't mutable.
+    unsafe { &*(slice as *const [T] as *const [MaybeUninit<T>]) }
+}
 
-    pub fn unsync_init(&self, init: impl FnOnce() -> bool) -> bool {
-        self.0.unsync_init(|| init() as usize) != 0
-    }
+/// View an mutable initialized array as potentially-uninitialized.
+///
+/// This is unsafe because it allows assigning uninitialized values into
+/// `slice`, which would be undefined behavior.
+#[inline(always)]
+pub unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
+    // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
+    &mut *(slice as *mut [T] as *mut [MaybeUninit<T>])
 }

--- a/imports/getrandom/src/util_libc.rs
+++ b/imports/getrandom/src/util_libc.rs
@@ -1,18 +1,17 @@
-// Copyright 2019 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 #![allow(dead_code)]
-use crate::{util::LazyUsize, Error};
-use core::{num::NonZeroU32, ptr::NonNull};
+use crate::Error;
+use core::{
+    mem::MaybeUninit,
+    num::NonZeroU32,
+    ptr::NonNull,
+    sync::atomic::{fence, AtomicPtr, Ordering},
+};
+use libc::c_void;
 
 cfg_if! {
     if #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "android"))] {
         use libc::__errno as errno_location;
-    } else if #[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "redox"))] {
+    } else if #[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "hurd", target_os = "redox"))] {
         use libc::__errno_location as errno_location;
     } else if #[cfg(any(target_os = "solaris", target_os = "illumos"))] {
         use libc::___errno as errno_location;
@@ -20,12 +19,16 @@ cfg_if! {
         use libc::__error as errno_location;
     } else if #[cfg(target_os = "haiku")] {
         use libc::_errnop as errno_location;
-    } else if #[cfg(all(target_os = "horizon", target_arch = "arm"))] {
+    } else if #[cfg(target_os = "nto")] {
+        use libc::__get_errno_ptr as errno_location;
+    } else if #[cfg(any(all(target_os = "horizon", target_arch = "arm"), target_os = "vita"))] {
         extern "C" {
             // Not provided by libc: https://github.com/rust-lang/libc/issues/1995
             fn __errno() -> *mut libc::c_int;
         }
         use __errno as errno_location;
+    } else if #[cfg(target_os = "aix")] {
+        use libc::_Errno as errno_location;
     }
 }
 
@@ -54,21 +57,24 @@ pub fn last_os_error() -> Error {
 //   - should return -1 and set errno on failure
 //   - should return the number of bytes written on success
 pub fn sys_fill_exact(
-    mut buf: &mut [u8],
-    sys_fill: impl Fn(&mut [u8]) -> libc::ssize_t,
+    mut buf: &mut [MaybeUninit<u8>],
+    sys_fill: impl Fn(&mut [MaybeUninit<u8>]) -> libc::ssize_t,
 ) -> Result<(), Error> {
     while !buf.is_empty() {
         let res = sys_fill(buf);
-        if res < 0 {
-            let err = last_os_error();
-            // We should try again if the call was interrupted.
-            if err.raw_os_error() != Some(libc::EINTR) {
-                return Err(err);
+        match res {
+            res if res > 0 => buf = buf.get_mut(res as usize..).ok_or(Error::UNEXPECTED)?,
+            -1 => {
+                let err = last_os_error();
+                // We should try again if the call was interrupted.
+                if err.raw_os_error() != Some(libc::EINTR) {
+                    return Err(err);
+                }
             }
-        } else {
-            // We don't check for EOF (ret = 0) as the data we are reading
+            // Negative return codes not equal to -1 should be impossible.
+            // EOF (ret = 0) should be impossible, as the data we are reading
             // should be an infinite stream of random bytes.
-            buf = &mut buf[(res as usize)..];
+            _ => return Err(Error::UNEXPECTED),
         }
     }
     Ok(())
@@ -76,37 +82,57 @@ pub fn sys_fill_exact(
 
 // A "weak" binding to a C function that may or may not be present at runtime.
 // Used for supporting newer OS features while still building on older systems.
-// F must be a function pointer of type `unsafe extern "C" fn`. Based off of the
-// weak! macro in libstd.
+// Based off of the DlsymWeak struct in libstd:
+// https://github.com/rust-lang/rust/blob/1.61.0/library/std/src/sys/unix/weak.rs#L84
+// except that the caller must manually cast self.ptr() to a function pointer.
 pub struct Weak {
     name: &'static str,
-    addr: LazyUsize,
+    addr: AtomicPtr<c_void>,
 }
 
 impl Weak {
+    // A non-null pointer value which indicates we are uninitialized. This
+    // constant should ideally not be a valid address of a function pointer.
+    // However, if by chance libc::dlsym does return UNINIT, there will not
+    // be undefined behavior. libc::dlsym will just be called each time ptr()
+    // is called. This would be inefficient, but correct.
+    // TODO: Replace with core::ptr::invalid_mut(1) when that is stable.
+    const UNINIT: *mut c_void = 1 as *mut c_void;
+
     // Construct a binding to a C function with a given name. This function is
     // unsafe because `name` _must_ be null terminated.
     pub const unsafe fn new(name: &'static str) -> Self {
         Self {
             name,
-            addr: LazyUsize::new(),
+            addr: AtomicPtr::new(Self::UNINIT),
         }
     }
 
-    // Return a function pointer if present at runtime. Otherwise, return null.
-    pub fn ptr(&self) -> Option<NonNull<libc::c_void>> {
-        let addr = self.addr.unsync_init(|| unsafe {
-            libc::dlsym(libc::RTLD_DEFAULT, self.name.as_ptr() as *const _) as usize
-        });
-        NonNull::new(addr as *mut _)
-    }
-}
-
-cfg_if! {
-    if #[cfg(any(target_os = "linux", target_os = "emscripten"))] {
-        use libc::open64 as open;
-    } else {
-        use libc::open;
+    // Return the address of a function if present at runtime. Otherwise,
+    // return None. Multiple callers can call ptr() concurrently. It will
+    // always return _some_ value returned by libc::dlsym. However, the
+    // dlsym function may be called multiple times.
+    pub fn ptr(&self) -> Option<NonNull<c_void>> {
+        // Despite having only a single atomic variable (self.addr), we still
+        // cannot always use Ordering::Relaxed, as we need to make sure a
+        // successful call to dlsym() is "ordered before" any data read through
+        // the returned pointer (which occurs when the function is called).
+        // Our implementation mirrors that of the one in libstd, meaning that
+        // the use of non-Relaxed operations is probably unnecessary.
+        match self.addr.load(Ordering::Relaxed) {
+            Self::UNINIT => {
+                let symbol = self.name.as_ptr() as *const _;
+                let addr = unsafe { libc::dlsym(libc::RTLD_DEFAULT, symbol) };
+                // Synchronizes with the Acquire fence below
+                self.addr.store(addr, Ordering::Release);
+                NonNull::new(addr)
+            }
+            addr => {
+                let func = NonNull::new(addr)?;
+                fence(Ordering::Acquire);
+                Some(func)
+            }
+        }
     }
 }
 
@@ -114,7 +140,7 @@ cfg_if! {
 pub unsafe fn open_readonly(path: &str) -> Result<libc::c_int, Error> {
     debug_assert_eq!(path.as_bytes().last(), Some(&0));
     loop {
-        let fd = open(path.as_ptr() as *const _, libc::O_RDONLY | libc::O_CLOEXEC);
+        let fd = libc::open(path.as_ptr() as *const _, libc::O_RDONLY | libc::O_CLOEXEC);
         if fd >= 0 {
             return Ok(fd);
         }

--- a/imports/getrandom/src/vita.rs
+++ b/imports/getrandom/src/vita.rs
@@ -1,16 +1,11 @@
-//! Implementation for macOS
+//! Implementation for PS Vita
 use crate::{util_libc::last_os_error, Error};
 use core::mem::MaybeUninit;
 
-extern "C" {
-    // Supported as of macOS 10.12+.
-    fn getentropy(buf: *mut u8, size: libc::size_t) -> libc::c_int;
-}
-
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(256) {
-        let ret = unsafe { getentropy(chunk.as_mut_ptr() as *mut u8, chunk.len()) };
-        if ret != 0 {
+        let ret = unsafe { libc::getentropy(chunk.as_mut_ptr() as *mut libc::c_void, chunk.len()) };
+        if ret == -1 {
             return Err(last_os_error());
         }
     }

--- a/imports/getrandom/src/vxworks.rs
+++ b/imports/getrandom/src/vxworks.rs
@@ -1,16 +1,11 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for VxWorks
 use crate::{util_libc::last_os_error, Error};
-use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use core::{
+    mem::MaybeUninit,
+    sync::atomic::{AtomicBool, Ordering::Relaxed},
+};
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static RNG_INIT: AtomicBool = AtomicBool::new(false);
     while !RNG_INIT.load(Relaxed) {
         let ret = unsafe { libc::randSecure() };
@@ -25,7 +20,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
 
     // Prevent overflow of i32
     for chunk in dest.chunks_mut(i32::max_value() as usize) {
-        let ret = unsafe { libc::randABytes(chunk.as_mut_ptr(), chunk.len() as i32) };
+        let ret = unsafe { libc::randABytes(chunk.as_mut_ptr() as *mut u8, chunk.len() as i32) };
         if ret != 0 {
             return Err(last_os_error());
         }

--- a/imports/getrandom/src/wasi.rs
+++ b/imports/getrandom/src/wasi.rs
@@ -1,19 +1,17 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for WASI
 use crate::Error;
-use core::num::NonZeroU32;
-use wasi::wasi_snapshot_preview1::random_get;
+use core::{
+    mem::MaybeUninit,
+    num::{NonZeroU16, NonZeroU32},
+};
+use wasi::random_get;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    match unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) } {
-        0 => Ok(()),
-        err => Err(unsafe { NonZeroU32::new_unchecked(err as u32) }.into()),
-    }
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    unsafe { random_get(dest.as_mut_ptr() as *mut u8, dest.len()) }.map_err(|e| {
+        // The WASI errno will always be non-zero, but we check just in case.
+        match NonZeroU16::new(e.raw()) {
+            Some(r) => Error::from(NonZeroU32::from(r)),
+            None => Error::ERRNO_NOT_POSITIVE,
+        }
+    })
 }

--- a/imports/getrandom/src/windows.rs
+++ b/imports/getrandom/src/windows.rs
@@ -1,13 +1,6 @@
-// Copyright 2018 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
+//! Implementation for Windows
 use crate::Error;
-use core::{ffi::c_void, num::NonZeroU32, ptr};
+use core::{ffi::c_void, mem::MaybeUninit, num::NonZeroU32, ptr};
 
 const BCRYPT_USE_SYSTEM_PREFERRED_RNG: u32 = 0x00000002;
 
@@ -21,20 +14,37 @@ extern "system" {
     ) -> u32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+// Forbidden when targetting UWP
+#[cfg(not(target_vendor = "uwp"))]
+#[link(name = "advapi32")]
+extern "system" {
+    #[link_name = "SystemFunction036"]
+    fn RtlGenRandom(RandomBuffer: *mut c_void, RandomBufferLength: u32) -> u8;
+}
+
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Prevent overflow of u32
     for chunk in dest.chunks_mut(u32::max_value() as usize) {
         // BCryptGenRandom was introduced in Windows Vista
         let ret = unsafe {
             BCryptGenRandom(
                 ptr::null_mut(),
-                chunk.as_mut_ptr(),
+                chunk.as_mut_ptr() as *mut u8,
                 chunk.len() as u32,
                 BCRYPT_USE_SYSTEM_PREFERRED_RNG,
             )
         };
         // NTSTATUS codes use the two highest bits for severity status.
         if ret >> 30 == 0b11 {
+            // Failed. Try RtlGenRandom as a fallback.
+            #[cfg(not(target_vendor = "uwp"))]
+            {
+                let ret =
+                    unsafe { RtlGenRandom(chunk.as_mut_ptr() as *mut c_void, chunk.len() as u32) };
+                if ret != 0 {
+                    continue;
+                }
+            }
             // We zeroize the highest bit, so the error code will reside
             // inside the range designated for OS codes.
             let code = ret ^ (1 << 31);

--- a/imports/getrandom/tests/common/mod.rs
+++ b/imports/getrandom/tests/common/mod.rs
@@ -12,7 +12,19 @@ fn test_zero() {
     getrandom_impl(&mut [0u8; 0]).unwrap();
 }
 
+// Return the number of bits in which s1 and s2 differ
+#[cfg(not(feature = "custom"))]
+fn num_diff_bits(s1: &[u8], s2: &[u8]) -> usize {
+    assert_eq!(s1.len(), s2.len());
+    s1.iter()
+        .zip(s2.iter())
+        .map(|(a, b)| (a ^ b).count_ones() as usize)
+        .sum()
+}
+
+// Tests the quality of calling getrandom on two large buffers
 #[test]
+#[cfg(not(feature = "custom"))]
 fn test_diff() {
     let mut v1 = [0u8; 1000];
     getrandom_impl(&mut v1).unwrap();
@@ -20,13 +32,35 @@ fn test_diff() {
     let mut v2 = [0u8; 1000];
     getrandom_impl(&mut v2).unwrap();
 
-    let mut n_diff_bits = 0;
-    for i in 0..v1.len() {
-        n_diff_bits += (v1[i] ^ v2[i]).count_ones();
-    }
+    // Between 3.5 and 4.5 bits per byte should differ. Probability of failure:
+    // ~ 2^(-94) = 2 * CDF[BinomialDistribution[8000, 0.5], 3500]
+    let d = num_diff_bits(&v1, &v2);
+    assert!(d > 3500);
+    assert!(d < 4500);
+}
 
-    // Check at least 1 bit per byte differs. p(failure) < 1e-1000 with random input.
-    assert!(n_diff_bits >= v1.len() as u32);
+// Tests the quality of calling getrandom repeatedly on small buffers
+#[test]
+#[cfg(not(feature = "custom"))]
+fn test_small() {
+    // For each buffer size, get at least 256 bytes and check that between
+    // 3 and 5 bits per byte differ. Probability of failure:
+    // ~ 2^(-91) = 64 * 2 * CDF[BinomialDistribution[8*256, 0.5], 3*256]
+    for size in 1..=64 {
+        let mut num_bytes = 0;
+        let mut diff_bits = 0;
+        while num_bytes < 256 {
+            let mut s1 = vec![0u8; size];
+            getrandom_impl(&mut s1).unwrap();
+            let mut s2 = vec![0u8; size];
+            getrandom_impl(&mut s2).unwrap();
+
+            num_bytes += size;
+            diff_bits += num_diff_bits(&s1, &s2);
+        }
+        assert!(diff_bits > 3 * num_bytes);
+        assert!(diff_bits < 5 * num_bytes);
+    }
 }
 
 #[test]

--- a/imports/getrandom/tests/rdrand.rs
+++ b/imports/getrandom/tests/rdrand.rs
@@ -6,10 +6,17 @@
 use getrandom::Error;
 #[macro_use]
 extern crate cfg_if;
+#[path = "../src/lazy.rs"]
+mod lazy;
 #[path = "../src/rdrand.rs"]
 mod rdrand;
 #[path = "../src/util.rs"]
 mod util;
 
-use rdrand::getrandom_inner as getrandom_impl;
+// The rdrand implementation has the signature of getrandom_uninit(), but our
+// tests expect getrandom_impl() to have the signature of getrandom().
+fn getrandom_impl(dest: &mut [u8]) -> Result<(), Error> {
+    rdrand::getrandom_inner(unsafe { util::slice_as_uninit_mut(dest) })?;
+    Ok(())
+}
 mod common;

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -33,7 +33,8 @@ gdbstub_arch = { version = "0.2.4", optional = true, default-features = false }
 armv7 = { git = "https://github.com/Foundation-Devices/armv7.git", branch = "update", features = [
     "critical-section",
 ] }
-atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master" }
+# FIXME: bring atsama5d27 target up to date so utralib dependency does not conflict
+# atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master" }
 xous-kernel = { package = "xous", version = "0.9.58", features = ["v2p"] }
 critical-section = "1.1.1"
 

--- a/loader/ed25519-dalek-loader/Cargo.toml
+++ b/loader/ed25519-dalek-loader/Cargo.toml
@@ -11,10 +11,10 @@ documentation = "https://docs.rs/ed25519-dalek"
 keywords = ["cryptography", "ed25519", "curve25519", "signature", "ECC"]
 categories = ["cryptography", "no-std"]
 description = "Fast and efficient ed25519 EdDSA key generations, signing, and verification in pure Rust."
-exclude = [ ".gitignore", "TESTVECTORS", "res/*" ]
+exclude = [".gitignore", "TESTVECTORS", "res/*"]
 
 [badges]
-travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master"}
+travis-ci = { repository = "dalek-cryptography/ed25519-dalek", branch = "master" }
 
 [package.metadata.docs.rs]
 # Disabled for now since this is borked; tracking https://github.com/rust-lang/docs.rs/issues/302
@@ -30,7 +30,7 @@ rand_core = { version = "0.5", default-features = false, optional = true }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true }
 serde_bytes = { version = "0.11", optional = true }
 sha2-loader = { path = "../sha2-loader", default-features = false }
-zeroize = { version = "~1.3", default-features = false }
+zeroize = { version = "1.7.0", default-features = false }
 
 [dev-dependencies]
 hex = "^0.4"
@@ -50,7 +50,12 @@ harness = false
 
 [features]
 default = ["std", "rand", "u64_backend"]
-std = ["curve25519-dalek-loader/std", "ed25519/std", "serde_crate/std", "rand/std"]
+std = [
+    "curve25519-dalek-loader/std",
+    "ed25519/std",
+    "serde_crate/std",
+    "rand/std",
+]
 alloc = ["curve25519-dalek-loader/alloc", "rand/alloc", "zeroize/alloc"]
 nightly = ["curve25519-dalek-loader/nightly"]
 serde = ["serde_crate", "serde_bytes", "ed25519/serde"]

--- a/services/aes/Cargo.toml
+++ b/services/aes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aes"
-version = "0.8.1"
+version = "0.8.3"
 authors = ["bunnie <bunnie@kosagi.com>"]
 edition = "2018"
 description = "AES library for Xous"

--- a/services/dns/Cargo.toml
+++ b/services/dns/Cargo.toml
@@ -26,7 +26,7 @@ trng = { path = "../trng" }
 # and the more logically grouped status crate has run out of resources.
 llio = { path = "../llio" }
 pddb = { path = "../pddb" }
-chrono = { version = "0.4.19", default-features = false, features = ["std"] }
+chrono = { version = "0.4.33", default-features = false, features = ["std"] }
 sntpc = { version = "0.3.1" }                                                 #, features = ["log"]
 locales = { path = "../../locales" }
 gam = { path = "../gam" }

--- a/services/dns/src/time.rs
+++ b/services/dns/src/time.rs
@@ -666,7 +666,7 @@ pub(crate) fn start_time_ux() {
                             match result {
                                 Ok(time) => {
                                     log::info!("Got NTP time: {}.{}", time.sec(), time.sec_fraction());
-                                    let current_time = Utc.ymd(1970, 1, 1).and_hms(0, 0, 0)
+                                    let current_time = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap()
                                         + chrono::Duration::seconds(time.sec() as i64);
                                     log::info!("Setting UTC time: {:?}", current_time.to_string());
                                     xous::send_message(
@@ -744,9 +744,17 @@ pub(crate) fn start_time_ux() {
                         }
 
                         log::info!("Setting time: {}/{}/{} {}:{}:{}", months, days, years, hours, mins, secs);
-                        let new_dt = chrono::FixedOffset::east((tz_offset_ms / 1000) as i32)
-                            .ymd(years as i32 + 2000, months as u32, days as u32)
-                            .and_hms(hours as u32, mins as u32, secs as u32);
+                        let new_dt = chrono::FixedOffset::east_opt((tz_offset_ms / 1000) as i32)
+                            .unwrap()
+                            .with_ymd_and_hms(
+                                years as i32 + 2000,
+                                months as u32,
+                                days as u32,
+                                hours as u32,
+                                mins as u32,
+                                secs as u32,
+                            )
+                            .unwrap();
                         xous::send_message(
                             timeserver_cid,
                             Message::new_scalar(

--- a/services/llio/Cargo.toml
+++ b/services/llio/Cargo.toml
@@ -30,10 +30,10 @@ xous-semver = "0.1.2"
 utralib = { version = "0.1.24", optional = true, default-features = false }
 
 [target.'cfg(any(windows,unix))'.dependencies]
-chrono = "0.4.19"
+chrono = "0.4.33"
 
 [dev-dependencies]
-"chrono" = "0.4.19"
+chrono = "0.4.33"
 
 [features]
 precursor = ["utralib/precursor"]

--- a/services/pddb/Cargo.toml
+++ b/services/pddb/Cargo.toml
@@ -38,8 +38,8 @@ rand_core = "0.6.4"
 sha2 = { version = "0.10.8" }
 digest = "0.10.7"
 hkdf = "0.12.4"
-zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
-zeroize_derive = "1.1.0"
+zeroize = { version = "1.7.0", features = ["zeroize_derive"] }
+zeroize_derive = "1.4.2"
 
 # bcrypt
 blowfish = { version = "0.9.1", features = ["bcrypt"] }

--- a/services/pddb/Cargo.toml
+++ b/services/pddb/Cargo.toml
@@ -32,13 +32,13 @@ aes-gcm-siv = { version = "0.11.1", default-features = false, features = [
 llio = { path = "../llio" }
 subtle = { version = "2.4.1", default-features = false }
 tts-frontend = { path = "../tts" }
-rand_core = "0.5.1"
+rand_core = "0.6.4"
 
 # passwords
 sha2 = { version = "0.10.8" }
-digest = "0.9.0"
+digest = "0.10.7"
 hkdf = "0.12.4"
-zeroize = "1.3.0"
+zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 zeroize_derive = "1.1.0"
 
 # bcrypt

--- a/services/root-keys/Cargo.toml
+++ b/services/root-keys/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = { version = "0.2.14", default-features = false }
 rkyv = { version = "0.4.3", default-features = false, features = [
     "const_generics",
 ] }
-zeroize = "1.3.0"
+zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 rand_core = "0.6.4"
 
 aes-kw = { version = "0.2.1", features = ["alloc"] }
@@ -71,14 +71,14 @@ byteorder = "1.4.3"                         # used by keywrap
 hex = { version = "0.4.3", default-features = false, features = [] }
 
 [dependencies.curve25519-dalek]
-version = "4.1.1"                       # note this is patched to our fork in ./Cargo.toml
+version = "4.1.1"        # note this is patched to our fork in ./Cargo.toml
 default-features = false
 
 [dependencies.ed25519-dalek]
 version = "2.1.0"
 #path = "../../../ed25519-dalek"
 default-features = false
-features = ["rand_core"]
+features = ["rand_core", "digest"]
 
 [features]
 precursor = ["utralib/precursor", "sha2/precursor"]

--- a/services/root-keys/Cargo.toml
+++ b/services/root-keys/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = { version = "0.2.14", default-features = false }
 rkyv = { version = "0.4.3", default-features = false, features = [
     "const_generics",
 ] }
-zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
+zeroize = { version = "1.7.0", features = ["zeroize_derive"] }
 rand_core = "0.6.4"
 
 aes-kw = { version = "0.2.1", features = ["alloc"] }

--- a/services/root-keys/Cargo.toml
+++ b/services/root-keys/Cargo.toml
@@ -33,7 +33,7 @@ aes-kw = { version = "0.2.1", features = ["alloc"] }
 
 # bcrypt
 cipher = "0.4.3"
-blowfish = { version = "0.8.0", features = ["bcrypt"] }
+blowfish = { version = "0.9.1", features = ["bcrypt"] }
 
 # password modals - keep them in this crate to minimize plaintext password manipulations
 gam = { path = "../gam" }

--- a/services/root-keys/Cargo.toml
+++ b/services/root-keys/Cargo.toml
@@ -21,13 +21,13 @@ xous-semver = "0.1.2"
 utralib = { version = "0.1.24", optional = true, default-features = false }
 
 xous-ipc = "0.9.57"
-num-derive = { version = "0.3.3", default-features = false }
+num-derive = { version = "0.4.1", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 rkyv = { version = "0.4.3", default-features = false, features = [
     "const_generics",
 ] }
 zeroize = "1.3.0"
-rand_core = "0.5.1"
+rand_core = "0.6.4"
 
 aes-kw = { version = "0.2.1", features = ["alloc"] }
 
@@ -63,7 +63,7 @@ keyboard = { path = "../keyboard" }
 # private keys
 #sha2 = {version = "0.9.5", default-features = false, features = []}
 sha2 = { version = "0.10.8" }
-digest = "0.9.0"
+digest = "0.10.7"
 aes = { path = "../aes" }
 engine-25519 = { path = "../engine-25519" }
 byteorder = "1.4.3"                         # used by keywrap
@@ -71,15 +71,14 @@ byteorder = "1.4.3"                         # used by keywrap
 hex = { version = "0.4.3", default-features = false, features = [] }
 
 [dependencies.curve25519-dalek]
-version = "3.1.0"                       # note this is patched to our fork in ./Cargo.toml
+version = "4.1.1"                       # note this is patched to our fork in ./Cargo.toml
 default-features = false
-features = ["u32_backend", "betrusted"]
 
 [dependencies.ed25519-dalek]
-version = "1.0.1"
+version = "2.1.0"
 #path = "../../../ed25519-dalek"
 default-features = false
-features = ["u32_backend", "rand"]
+features = ["rand_core"]
 
 [features]
 precursor = ["utralib/precursor", "sha2/precursor"]

--- a/services/root-keys/src/api.rs
+++ b/services/root-keys/src/api.rs
@@ -1,7 +1,6 @@
 mod rkyv_enum;
 use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
-
 pub use rkyv_enum::*;
 
 pub(crate) const SERVER_NAME_KEYS: &str = "_Root key server and update manager_";

--- a/services/root-keys/src/api.rs
+++ b/services/root-keys/src/api.rs
@@ -1,6 +1,7 @@
 mod rkyv_enum;
 use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
+
 pub use rkyv_enum::*;
 
 pub(crate) const SERVER_NAME_KEYS: &str = "_Root key server and update manager_";

--- a/services/root-keys/src/bcrypt.rs
+++ b/services/root-keys/src/bcrypt.rs
@@ -62,9 +62,9 @@ pub fn bcrypt(cost: u32, salt: &[u8], pw: &str, output: &mut [u8]) {
     for i in 0..3 {
         let i: usize = i * 2;
         for _ in 0..64 {
-            let (l, r) = state.bc_encrypt(ctext[i], ctext[i + 1]);
-            ctext[i] = l;
-            ctext[i + 1] = r;
+            let lr = state.bc_encrypt([ctext[i], ctext[i + 1]]);
+            ctext[i] = lr[0];
+            ctext[i + 1] = lr[1];
         }
 
         let buf = ctext[i].to_be_bytes();

--- a/services/root-keys/src/main.rs
+++ b/services/root-keys/src/main.rs
@@ -99,7 +99,7 @@ mod implementation {
 
     use aes::cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
     use aes::Aes256;
-    use ed25519_dalek::PublicKey;
+    use ed25519_dalek::VerifyingKey;
     use gam::modal::{Modal, Slider};
     use gam::{ActionType, ProgressBar};
     use locales::t;
@@ -255,7 +255,7 @@ mod implementation {
 
         pub fn finish_key_init(&mut self) {}
 
-        pub fn verify_gateware_self_signature(&mut self, _pk: Option<&PublicKey>) -> bool { true }
+        pub fn verify_gateware_self_signature(&mut self, _pk: Option<&VerifyingKey>) -> bool { true }
 
         pub fn test(
             &mut self,

--- a/services/root-keys/src/sha512_digest.rs
+++ b/services/root-keys/src/sha512_digest.rs
@@ -52,7 +52,7 @@ impl fmt::Debug for Sha512Prehash {
 }
 
 impl UpdateCore for Sha512Prehash {
-    fn update_blocks(&mut self, blocks: &[Block<Self>]) {
+    fn update_blocks(&mut self, _blocks: &[Block<Self>]) {
         panic!("Prehash implementation can't take block updates");
     }
 }
@@ -60,9 +60,9 @@ impl UpdateCore for Sha512Prehash {
 impl VariableOutputCore for Sha512Prehash {
     const TRUNC_SIDE: TruncSide = TruncSide::Left;
 
-    fn new(output_size: usize) -> Result<Self, InvalidOutputSize> { Ok(Self { hash: None }) }
+    fn new(_output_size: usize) -> Result<Self, InvalidOutputSize> { Ok(Self { hash: None }) }
 
-    fn finalize_variable_core(&mut self, buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
+    fn finalize_variable_core(&mut self, _buffer: &mut Buffer<Self>, out: &mut Output<Self>) {
         for (dest, &src) in out.chunks_exact_mut(1).zip(self.hash.unwrap().iter()) {
             dest.copy_from_slice(&[src])
         }
@@ -71,7 +71,7 @@ impl VariableOutputCore for Sha512Prehash {
 
 impl Update for Sha512Prehash {
     /// Update state using the provided data.
-    fn update(&mut self, data: &[u8]) {
+    fn update(&mut self, _data: &[u8]) {
         panic!("Prehash implementation can't take block updates");
     }
 }

--- a/services/shellchat/Cargo.toml
+++ b/services/shellchat/Cargo.toml
@@ -25,9 +25,9 @@ keyboard = { path = "../keyboard" }
 susres = { package = "xous-api-susres", version = "0.9.53" }
 codec = { path = "../codec" }
 sha2 = { version = "0.10.8" }
-digest = "0.9.0"
+digest = "0.10.7"
 aes = { path = "../aes" }
-cipher = "0.3.0"
+cipher = "0.4.4"
 engine-25519 = { path = "../engine-25519" }
 spinor = { path = "../spinor" }
 root-keys = { path = "../root-keys" }
@@ -44,7 +44,7 @@ locales = { path = "../../locales" }
 
 trng = { path = "../trng" }
 
-num-derive = { version = "0.3.3", default-features = false }
+num-derive = { version = "0.4.1", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 rkyv = { version = "0.4.3", default-features = false, features = [
     "const_generics",
@@ -97,20 +97,20 @@ random-pick = { version = "1.2.15", optional = true }
 hex = { version = "0.4.3", default-features = false, features = [] }
 #sha2 = {version = "0.9.5", default-features = false, features = []}
 [dependencies.curve25519-dalek]
-version = "3.1.0"                       # note this is patched to our fork in ./Cargo.toml
+version = "4.1.1"                       # note this is patched to our fork in ./Cargo.toml
 default-features = false
-features = ["u32_backend", "betrusted"]
 
 [dependencies.x25519-dalek]
-version = "1.1.1"
+version = "2.0.0"
+# TODO: static_secrets is only needed by the engine tests. Ideally, we would put the static_secrets version in dev deps only
 default-features = false
-features = ["u32_backend"]
+features = ["static_secrets"]
 
 [dependencies.ed25519-dalek]
-version = "1.0.1"
+version = "2.1.0"
 #path = "../../../ed25519-dalek"
 default-features = false
-features = ["u32_backend", "rand"]
+features = ["rand_core"]
 
 [features]
 precursor = ["utralib/precursor", "sha2/precursor"]

--- a/services/shellchat/Cargo.toml
+++ b/services/shellchat/Cargo.toml
@@ -90,7 +90,7 @@ tungstenite = { version = "0.20.0", optional = true }
 
 # for performance testing
 perflib = { path = "../../libs/perflib", optional = true }
-random-pick = { version = "1.2.15", optional = true }
+random-pick = { version = "1.2.16", optional = true }
 
 # for the curve25519 tests
 # hardware acceleration adaptations are inserted into a fork of the main branch.

--- a/services/shellchat/Cargo.toml
+++ b/services/shellchat/Cargo.toml
@@ -145,6 +145,7 @@ shellperf = [
 ] # this also needs the project-wide "perfcounter" feature to be selected. shellchat is the exclusive manager of the performance counter, do not use with e.g. "vaultperf" feature
 extra-tests = []
 mass-storage = []
+rand-api = []
 locktests = [
 ] # for debugging some specific `std` tests cherry-picked out of the test suite
 default = [] # "debugprint"

--- a/services/shellchat/Cargo.toml
+++ b/services/shellchat/Cargo.toml
@@ -50,7 +50,7 @@ rkyv = { version = "0.4.3", default-features = false, features = [
     "const_generics",
 ] }
 
-chrono = { version = "0.4.19", default-features = false, features = ["std"] }
+chrono = { version = "0.4.33", default-features = false, features = ["std"] }
 
 # for audio self-test analysis
 base64 = "0.20.0"
@@ -97,7 +97,7 @@ random-pick = { version = "1.2.15", optional = true }
 hex = { version = "0.4.3", default-features = false, features = [] }
 #sha2 = {version = "0.9.5", default-features = false, features = []}
 [dependencies.curve25519-dalek]
-version = "4.1.1"                       # note this is patched to our fork in ./Cargo.toml
+version = "4.1.1"        # note this is patched to our fork in ./Cargo.toml
 default-features = false
 
 [dependencies.x25519-dalek]

--- a/services/shellchat/src/cmds/rtc_cmd.rs
+++ b/services/shellchat/src/cmds/rtc_cmd.rs
@@ -36,8 +36,8 @@ impl<'a> ShellCmdApi<'a> for RtcCmd {
                     let mut localtime = llio::LocalTime::new();
                     if let Some(timestamp) = localtime.get_local_time_ms() {
                         // we "say" UTC but actually local time is in whatever the local time is
-                        let dt = chrono::DateTime::<Utc>::from_utc(
-                            NaiveDateTime::from_timestamp(timestamp as i64 / 1000, 0),
+                        let dt = chrono::DateTime::<Utc>::from_naive_utc_and_offset(
+                            NaiveDateTime::from_timestamp_opt(timestamp as i64 / 1000, 0).unwrap(),
                             chrono::offset::Utc,
                         );
                         let timestr = dt.format("%m/%d/%Y %T").to_string();

--- a/services/shellchat/src/cmds/trng_cmd.rs
+++ b/services/shellchat/src/cmds/trng_cmd.rs
@@ -81,8 +81,9 @@ impl<'a> ShellCmdApi<'a> for TrngCmd {
                     }
                     write!(ret, "Pumped {}x1k values out of the engine", ROUNDS).unwrap();
                 }
-                // rand_core API tests - commented out because they only need to be run once, basically.
-                /*
+                // rand_core API tests - not included by default because it only needs to be run whenever
+                // the rand API is updated
+                #[cfg(feature = "rand-api")]
                 "api" => {
                     // the purpose of these tests is to check the edge-case code because
                     // the trng fetch is u32, but rand_core allows u8
@@ -143,7 +144,7 @@ impl<'a> ShellCmdApi<'a> for TrngCmd {
                     let mut test4100 = [0u8; 4100];
                     OsRng.fill_bytes(&mut test4100);
                     log::info!("test 4100: {:?}", &test4100[4092..]);
-                } */
+                }
                 "errs" => {
                     write!(ret, "TRNG error stats: {:?}", env.trng.get_error_stats().unwrap()).unwrap();
                 }

--- a/services/status/Cargo.toml
+++ b/services/status/Cargo.toml
@@ -39,7 +39,7 @@ rkyv = { version = "0.4.3", default-features = false, features = [
     "const_generics",
 ] }
 
-chrono = { version = "0.4.19", default-features = false, features = ["std"] }
+chrono = { version = "0.4.33", default-features = false, features = ["std"] }
 crossbeam = "0.8.2"
 
 sha2 = { version = "0.10.8" }
@@ -51,7 +51,7 @@ utralib = { version = "0.1.24", optional = true, default-features = false }
 
 # short circuit the datetime call on hosted mode
 [target.'cfg(any(windows,unix))'.dependencies]
-chrono = "0.4.19"
+chrono = "0.4.33"
 
 [features]
 precursor = ["utralib/precursor", "sha2/precursor"]

--- a/services/status/Cargo.toml
+++ b/services/status/Cargo.toml
@@ -43,7 +43,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["std"] }
 crossbeam = "0.8.2"
 
 sha2 = { version = "0.10.8" }
-digest = "0.9.0"
+digest = "0.10.7"
 xous-semver = "0.1.2"
 com_rs = { git = "https://github.com/betrusted-io/com_rs", rev = "891bdd3ca8e41f81510d112483e178aea3e3a921" }
 

--- a/services/status/src/main.rs
+++ b/services/status/src/main.rs
@@ -530,8 +530,8 @@ fn wrapped_main() -> ! {
                     // once we have unlocked the PDDB and know our timezone, we'll compare the embedded
                     // timestamp to our current time, and delete the backup if it's too
                     // old.
-                    backup_time = Some(chrono::DateTime::<Utc>::from_utc(
-                        NaiveDateTime::from_timestamp(header.timestamp as i64, 0),
+                    backup_time = Some(chrono::DateTime::<Utc>::from_naive_utc_and_offset(
+                        NaiveDateTime::from_timestamp_opt(header.timestamp as i64, 0).unwrap(),
                         chrono::offset::Utc,
                     ));
                 }
@@ -1234,8 +1234,8 @@ fn wrapped_main() -> ! {
                     uptime_tv.clear_str();
                     if let Some(timestamp) = localtime.get_local_time_ms() {
                         // we "say" UTC but actually local time is in whatever the local time is
-                        let dt = chrono::DateTime::<Utc>::from_utc(
-                            NaiveDateTime::from_timestamp(timestamp as i64 / 1000, 0),
+                        let dt = chrono::DateTime::<Utc>::from_naive_utc_and_offset(
+                            NaiveDateTime::from_timestamp_opt(timestamp as i64 / 1000, 0).unwrap(),
                             chrono::offset::Utc,
                         );
                         let timestr = dt.format("%H:%M %m/%d").to_string();

--- a/services/trng/Cargo.toml
+++ b/services/trng/Cargo.toml
@@ -12,14 +12,14 @@ log-server = { package = "xous-api-log", version = "0.1.53" }
 ticktimer-server = { package = "xous-api-ticktimer", version = "0.9.53" }
 xous-names = { package = "xous-api-names", version = "0.9.55" }
 log = "0.4.14"
-num-derive = { version = "0.3.3", default-features = false }
+num-derive = { version = "0.4.1", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
 susres = { package = "xous-api-susres", version = "0.9.53" }
 rkyv = { version = "0.4.3", default-features = false, features = [
     "const_generics",
 ] }
 xous-ipc = "0.9.57"
-rand_core = "0.5.1" # the 0.5.1 API is necessary for compatibility with curve25519-dalek crates
+rand_core = "0.6.4" # the 0.6.4 API is necessary for compatibility with curve25519-dalek crates
 utralib = { version = "0.1.24", optional = true, default-features = false }
 
 [target.'cfg(any(windows,unix))'.dependencies]

--- a/services/trng/src/lib.rs
+++ b/services/trng/src/lib.rs
@@ -150,7 +150,7 @@ impl Trng {
         .expect("TRNG|LIB: can't set test mode");
     }
 
-    /// Gets test data from the TRNG. If hte test mode was not previously set, this will
+    /// Gets test data from the TRNG. If the test mode was not previously set, this will
     /// eventually cause a panic. We don't add extra overhead code to make this safer
     /// because as a test mode the caller expected to know what they are doing (and adding
     /// more safety code increases overhead for the 99.9999999% of the time when we aren't

--- a/services/xous-log/Cargo.toml
+++ b/services/xous-log/Cargo.toml
@@ -28,13 +28,14 @@ cramium-hal = { path = "../../libs/cramium-hal", optional = true, default-featur
     "std",
 ] }
 
-[target.'cfg(target_arch = "arm")'.dependencies]
-atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master", features = [
-    "lcd-console",
-] }
-xous = { version = "0.9.58", features = [
-    "v2p",
-] } # v2p feature is used when lcd-console feature is turned on
+# FIXME: bring atsama5d27 target up to date so utralib dependency does not conflict
+# [target.'cfg(target_arch = "arm")'.dependencies]
+# atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master", features = [
+#     "lcd-console",
+# ] }
+# xous = { version = "0.9.58", features = [
+#     "v2p",
+# ] } # v2p feature is used when lcd-console feature is turned on
 
 [features]
 cramium-soc = ["utralib/cramium-soc", "cramium-hal"]

--- a/services/xous-log/Cargo.toml
+++ b/services/xous-log/Cargo.toml
@@ -28,13 +28,14 @@ cramium-hal = { path = "../../libs/cramium-hal", optional = true, default-featur
     "std",
 ] }
 
-[target.'cfg(target_arch = "arm")'.dependencies]
-atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master", features = [
-    "lcd-console",
-] }
-xous = { version = "0.9.57", features = [
-    "v2p",
-] } # v2p feature is used when lcd-console feature is turned on
+# this depends on an old version of svd2utra. Removing for now. TODO: fix this
+#[target.'cfg(target_arch = "arm")'.dependencies]
+#atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master", features = [
+#    "lcd-console",
+#] }
+#xous = { version = "0.9.57", features = [
+#    "v2p",
+#] } # v2p feature is used when lcd-console feature is turned on
 
 [features]
 cramium-soc = ["utralib/cramium-soc", "cramium-hal"]

--- a/services/xous-ticktimer/Cargo.toml
+++ b/services/xous-ticktimer/Cargo.toml
@@ -25,11 +25,12 @@ num-traits = { version = "0.2.14", default-features = false }
 xous-semver = "0.1.2"
 utralib = { version = "0.1.24", optional = true, default-features = false }
 
-[target.'cfg(target_arch = "arm")'.dependencies]
-atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master" }
+# TODO: fix this
+#[target.'cfg(target_arch = "arm")'.dependencies]
+#atsama5d27 = { git = "https://github.com/Foundation-Devices/atsama5d27.git", branch = "master" }
 
 [features]
-atsama5d27 = ["utralib/atsama5d27"]
+#atsama5d27 = ["utralib/atsama5d27"]
 
 # you may want to remove the watchdog feature if you're debugging a crash, as it will force the system to reboot automatically
 precursor = ["utralib/precursor", "susres/precursor", "watchdog"]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -20,8 +20,8 @@ pem = "0.8.3"
 svd2utra = "0.1.22"
 xmas-elf = "0.9.0"
 xous-semver = "0.1.2"
-ed25519-dalek = "1.0.1"
-sha2 = { version = "0.9.5" }
+ed25519-dalek = { version = "2.1.0", features = ["digest"] }
+sha2 = { version = "0.10.8" }
 pkcs8 = { version = "0.8.0", features = ["pem"] }
 base64 = "0.20.0"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,7 +12,7 @@ atty = "0.2.14"
 filetime = "0.2.14"
 rustc_version = "0.4.0"
 zip = "0.6.4"
-chrono = "0.4"
+chrono = "0.4.33"
 serde_json = "1.0.41"
 serde = { version = "1.0.130", features = ["derive"] }
 tempfile = "3.3.0"


### PR DESCRIPTION
This PR should clean up all the remaining crypto-related APIs to the latest pins, with the exception of p256 inside `vault` because it's inside some code that I didn't write and thus am a little scared to change since I don't know how to verify if the change worked or not.

This is all lightly tested on real hardware; if you feel like this patch set can get you moving on the Signal port, please go ahead and submit a PR back to the mainline so I can merge this and run it against the full CI suite.

Because the change is pretty heavy and in security-sensitive portions of the core, it'll need more scrutiny and testing than usual.
